### PR TITLE
fix: Fix UserInfoEditViewModel timer duplication bug

### DIFF
--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditViewModel.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditViewModel.kt
@@ -268,7 +268,6 @@ class UserInfoEditViewModel @Inject constructor(
                 )
             }
         }
-        postSideEffect(UserInfoEditSideEffect.StartTimer)
     }
 
     fun checkVerificationCode() = intent {


### PR DESCRIPTION
## PR 개요
이슈 번호: #2

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
UserInfoEditViewModel.requestVerificationCode() 함수에서 onSuccess/onFailure 블록 외부에 위치한 중복 postSideEffect(UserInfoEditSideEffect.StartTimer) 호출을 제거하여 타이머 이중 발동 및 실패 시 오발동 버그를 수정했습니다.
feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditViewModel.kt 파일의 requestVerificationCode() 함수에서 onSuccess 블록 외부에 위치한 postSideEffect(UserInfoEditSideEffect.StartTimer) 호출을 제거했습니다. 이로써 인증 코드 요청 성공 시 StartTimer SideEffect가 1회만 발동되고, 실패 시에는 발동되지 않도록 수정했습니다.

### 논의 사항
(없음)

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다