### PR TITLE
refactor: Integrate Dining Nested Scroll to Core

### DIFF
--- a/.maestro/common/launch_app.yaml
+++ b/.maestro/common/launch_app.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - stopApp
 - openLink: "koin://main/navigation"

--- a/.maestro/common/open_drawer.yaml
+++ b/.maestro/common/open_drawer.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: launch_app.yaml
 - tapOn:

--- a/.maestro/suites/student_guest_smoke.yaml
+++ b/.maestro/suites/student_guest_smoke.yaml
@@ -12,6 +12,7 @@ env:
 - runFlow: ../guest/store.yaml
 - runFlow: ../guest/bus.yaml
 - runFlow: ../guest/dining.yaml
+- runFlow: ../feature/dining_detail_header_collapse_regression.yaml
 - runFlow: ../guest/timetable.yaml
 - runFlow: ../guest/club.yaml
 - runFlow: ../guest/callvan.yaml


### PR DESCRIPTION
## PR 개요
이슈 번호: #1

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
`feature/dining` 모듈의 식단 화면 Nested Scroll 로직을 `core` 공통 구현을 활용하도록 리팩토링했습니다. `DiningScrollConnection.kt`를 `KoinNestedScrollConnection`을 상속하는 `DiningNestedScrollConnection` 클래스로 교체하고, `DiningDetailScreen.kt`에서 `rememberKoinNestedScrollHeaderState`를 사용하여 상태를 관리하도록 변경했습니다. 기존 헤더 높이 애니메이션(50ms 보간) 동작은 유지됩니다.

주요 변경사항은 다음과 같습니다:
- `DiningScrollConnection.kt` 팩토리 함수를 `DiningNestedScrollConnection` 클래스로 전환하여 `KoinNestedScrollConnection`과의 일관성을 확보했습니다.
- `DiningDetailScreen.kt`에서 `rememberKoinNestedScrollHeaderState`를 사용하고, `animateDpAsState(tween(50))`의 `targetValue`로 `headerState.currentHeaderHeightDp()`를 연결하여 기존 50ms 보간 애니메이션을 유지했습니다.
- `DiningNestedScrollConnection`의 `onPreScroll`에서 스크롤 업 시 잔여 delta를 사용하여 헤더를 확장하는 로직을 기존과 동일하게 구현했습니다.
- `onPostScroll`과 `onPostFling`은 각각 `Offset.Zero`와 `Velocity.Zero`를 반환하여 스냅 동작을 비활성화하고 기존 동작을 유지했습니다.

### 논의 사항
기존 식단 화면 Nested Scroll 로직(`feature/dining`)을 `core` 모듈의 공통 구현(`KoinNestedScrollConnection`, `KoinNestedScrollHeaderState`)을 사용하도록 리팩토링했습니다. 동작의 일관성을 유지하기 위해, 특히 헤더 높이 애니메이션의 50ms 보간을 그대로 유지하고 스크롤 동작(delta 계산, snap 비활성화)을 기존과 동일하게 구현했습니다.

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다