### PR TITLE
[Refactor] 식단 화면 Nested Scroll 로직을 Core 공통 구현으로 통합

### DIFF
--- a/.maestro/common/launch_app.yaml
+++ b/.maestro/common/launch_app.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - stopApp
 - openLink: "koin://main/navigation"

--- a/.maestro/common/open_drawer.yaml
+++ b/.maestro/common/open_drawer.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: launch_app.yaml
 - tapOn:

--- a/.maestro/suites/student_guest_smoke.yaml
+++ b/.maestro/suites/student_guest_smoke.yaml
@@ -12,6 +12,7 @@ env:
 - runFlow: ../guest/store.yaml
 - runFlow: ../guest/bus.yaml
 - runFlow: ../guest/dining.yaml
+- runFlow: ../feature/dining_detail_header_collapse_regression.yaml
 - runFlow: ../guest/timetable.yaml
 - runFlow: ../guest/club.yaml
 - runFlow: ../guest/callvan.yaml


### PR DESCRIPTION
## PR 개요
이슈 번호: #1

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
feature/dining 모듈에서 자체 구현했던 `diningScrollConnection()` 팩토리 함수를 제거하고, `core` 모듈의 `KoinNestedScrollConnection` 및 `KoinNestedScrollHeaderState` 공통 구현을 상속받는 `DiningNestedScrollConnection` 클래스를 새로 생성하여 사용합니다. 이로써 중복 코드를 제거하고 공통 컴포넌트 활용을 통해 코드의 일관성을 높입니다.

또한, CODE_REVIEW에서 지적된 `pendingOffset` 캐시로 인한 헤더 상태 동기화 불일치 문제를 해결했습니다. 이전에는 업스크롤 시에만 `pendingOffset`이 갱신되어 다음 업스크롤 시 stale 기준값으로 계산되는 문제가 있었으나, 이제는 매 호출마다 최신 `state.headerOffsetPx` 값을 기준으로 계산하여 스크롤 방향 전환 후에도 항상 실제 헤더 오프셋을 기준으로 올바르게 동작하도록 수정했습니다.

### 논의 사항
Dining 화면의 `onPreScroll` 동작은 다른 모듈과 차이가 있어 `KoinNestedScrollConnection`을 상속하는 `DiningNestedScrollConnection`에서 해당 로직을 오버라이드하여 원본 동작(리스트 top 도달 직전 제스처에서 헤더 같은 프레임 확장)을 재현합니다.
툴바 높이 애니메이션은 기존 50ms `tween` 애니메이션 특성을 유지하기 위해 `animateDpAsState(tween(durationMillis = 50))`를 사용합니다. 플링 후 snap이 없는 기존 Dining 화면의 동작을 유지하기 위해 `onPostScroll` 및 `onPostFling` 메서드는 `Offset.Zero` 및 `Velocity.Zero`를 반환하도록 구현했습니다.

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다