### PR TITLE
[Fix] Race Condition으로 중복 이메일 사용자도 회원가입 API가 호출됨

### DIFF
--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/general/SignUpGeneralViewModel.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/general/SignUpGeneralViewModel.kt
@@ -12,7 +12,6 @@ import `in`.koreatech.koin.domain.usecase.signup.CheckLoginIdDuplicateUseCase
 import `in`.koreatech.koin.domain.usecase.signup.CheckNicknameDuplicateUseCase
 import `in`.koreatech.koin.domain.usecase.signup.PostGeneralRegisterUseCase
 import `in`.koreatech.koin.domain.util.ext.isValidLoginId
-import `in`.koreatech.koin.feature.user.KOREATECH_EMAIL_DOMAIN
 import `in`.koreatech.koin.feature.user.ui.signup.navigation.GENDER
 import `in`.koreatech.koin.feature.user.ui.signup.navigation.NAME
 import `in`.koreatech.koin.feature.user.ui.signup.navigation.PHONE_NUMBER
@@ -151,33 +150,22 @@ class SignUpGeneralViewModel @Inject constructor(
         }
     }
 
-    private fun checkEmailDuplicate() = intent {
-        if (state.email == "") return@intent
-        checkEmailDuplicateUseCase("${state.email}@$KOREATECH_EMAIL_DOMAIN").onSuccess {
-            reduce {
-                state.copy(isEmailAvailable = true)
-            }
-        }.onFailure {
-            when (it) {
-                is KoinUserException.EmailConflictException -> {
-                    reduce {
-                        state.copy(isEmailAvailable = false)
+    fun signUp() = intent {
+        if (state.email.isNotEmpty()) {
+            checkEmailDuplicateUseCase(state.email).onSuccess {
+                reduce { state.copy(isEmailAvailable = true) }
+            }.onFailure {
+                when (it) {
+                    is KoinUserException.EmailConflictException -> {
+                        reduce { state.copy(isEmailAvailable = false) }
                     }
-                }
 
-                else -> {
-                    // We check email validation with regex.
-                    // So, Don't check email validation from API response.
-                    reduce {
-                        state.copy(isEmailAvailable = null)
+                    else -> {
+                        reduce { state.copy(isEmailAvailable = null) }
                     }
                 }
             }
         }
-    }
-
-    fun signUp() = intent {
-        checkEmailDuplicate()
         if (state.isEmailAvailable == false) return@intent
         postGeneralRegisterUseCase(
             name = state.name,

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/student/SignUpStudentViewModel.kt
@@ -189,33 +189,22 @@ class SignUpStudentViewModel @Inject constructor(
         }
     }
 
-    private fun checkEmailDuplicate() = intent {
-        if (state.email == "") return@intent
-        checkEmailDuplicateUseCase("${state.email}@$KOREATECH_EMAIL_DOMAIN").onSuccess {
-            reduce {
-                state.copy(isEmailAvailable = true)
-            }
-        }.onFailure {
-            when (it) {
-                is KoinUserException.EmailConflictException -> {
-                    reduce {
-                        state.copy(isEmailAvailable = false)
+    fun signUp() = intent {
+        if (state.email.isNotEmpty()) {
+            checkEmailDuplicateUseCase("${state.email}@$KOREATECH_EMAIL_DOMAIN").onSuccess {
+                reduce { state.copy(isEmailAvailable = true) }
+            }.onFailure {
+                when (it) {
+                    is KoinUserException.EmailConflictException -> {
+                        reduce { state.copy(isEmailAvailable = false) }
                     }
-                }
 
-                else -> {
-                    // We check email validation with regex.
-                    // So, Don't check email validation from API response.
-                    reduce {
-                        state.copy(isEmailAvailable = null)
+                    else -> {
+                        reduce { state.copy(isEmailAvailable = null) }
                     }
                 }
             }
         }
-    }
-
-    fun signUp() = intent {
-        checkEmailDuplicate()
         if (state.isEmailAvailable == false) return@intent
         postStudentRegisterUseCase(
             name = state.name,


### PR DESCRIPTION
## PR 개요
이슈 번호: #3

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
Race Condition으로 인해 중복 이메일 사용자가 회원가입 API 호출되는 버그를 수정했습니다.
`private fun checkEmailDuplicate()`를 제거하고 `signUp()` 메서드 내부에 인라인하여, Orbit MVI의 `intent { }` 블록 내에서 코루틴이 순차적으로 실행되도록 변경했습니다.
일반 회원가입 경로에서 발생하는 이중 도메인 버그를 수정하여 `state.email` 값을 그대로 `checkEmailDuplicateUseCase`에 전달합니다.
학생 회원가입 경로에서는 `state.email` 값에 `@koreatech.ac.kr` 도메인을 조합하여 `checkEmailDuplicateUseCase`를 호출합니다.
네트워크 오류 시 `isEmailAvailable`이 `null`로 설정되는 기존 동작은 유지됩니다.

### 논의 사항
- Race condition 및 일반 회원가입 이중 도메인 버그 수정.
- 각 회원가입 경로에 맞는 이메일 형식으로 중복 검사 로직 적용.
- 네트워크 오류 발생 시 `isEmailAvailable`은 null 유지 (기존 의도된 동작).

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다