### PR TITLE
[Fix] 비밀번호 찾기 - 인증 코드 발송 실패 시 타이머 시작 버그 수정

### DIFF
--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/findpassword/verification/FindPasswordVerificationViewModel.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/findpassword/verification/FindPasswordVerificationViewModel.kt
@@ -102,7 +102,6 @@ class FindPasswordVerificationViewModel @Inject constructor(
     }
 
     private fun sendVerificationCode() = intent {
-        postSideEffect(FindPasswordVerificationSideEffect.StartTimer)
         if (state.isSms) {
             requestSmsVerificationUseCase(state.verificationMethod)
         } else {
@@ -118,6 +117,7 @@ class FindPasswordVerificationViewModel @Inject constructor(
                     verificationCodeState = VerificationCodeState.None
                 )
             }
+            postSideEffect(FindPasswordVerificationSideEffect.StartTimer)
         }.onFailure {
             reduce {
                 state.copy(


### PR DESCRIPTION
## PR 개요
이슈 번호: #5

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
`FindPasswordVerificationViewModel.sendVerificationCode()` 메서드에서 SMS/이메일 인증 코드 발송 API 호출 실패 시에도 타이머가 시작되는 버그를 수정했습니다.
기존에는 API 호출 전에 `postSideEffect(FindPasswordVerificationSideEffect.StartTimer)`가 실행되어, API 응답 결과와 무관하게 타이머가 항상 시작되었습니다.
수정 후에는 `postSideEffect(FindPasswordVerificationSideEffect.StartTimer)`를 `.onSuccess { }` 블록 내 `reduce { }` 이후로 이동시켜, API 성공 시에만 타이머가 정상적으로 시작되도록 변경했습니다.
이는 `FindIdVerificationViewModel`의 구현 패턴을 따릅니다.

### 논의 사항
- `IMPL.md`의 문서화 오류: `IMPL.md`에 기재된 신규 파일 `local.properties`가 실제 git diff에 존재하지 않습니다. 하지만 작업 규칙에 따라 `IMPL.md`와 같은 산출물 파일은 수정이 불가하여, 해당 문서화 오류는 그대로 유지됩니다.

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다