### PR TITLE
[Fix] 채팅 메시지 로드 실패 시 isLoading 상태 고착 문제 해결

### DIFF
--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/ChatRoomViewModel.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/ChatRoomViewModel.kt
@@ -127,7 +127,10 @@ class ChatRoomViewModel @Inject constructor(
                     postSideEffect(ChatRoomSideEffect.BlockedByUser)
                 }
 
-                else -> Timber.e(e)
+                else -> {
+                    Timber.e(e)
+                    reduce { state.copy(isLoading = false) }
+                }
             }
         }
     }
@@ -191,6 +194,7 @@ class ChatRoomViewModel @Inject constructor(
             }
         }.onFailure {
             Timber.e(it)
+            reduce { state.copy(isLoading = false) }
         }
     }
 


### PR DESCRIPTION
## PR 개요
이슈 번호: #7

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
채팅 메시지 로드 실패 시 `isLoading` 상태가 리셋되지 않아 로딩 인디케이터가 화면에 고착되는 버그를 수정했습니다.

- `ChatRoomViewModel.getChatRoom()` 메서드의 `else` 분기(BlockedException 이 아닌 경우)에서 네트워크 오류 발생 시 `isLoading` 상태를 `false`로 복구합니다.
- `ChatRoomViewModel.getChatMessages()` 메서드의 `onFailure` 블록에서도 동일하게 `isLoading` 상태를 `false`로 복구합니다.

### 논의 사항
기존 `GroupChatViewModel`, `CallvanDetailViewModel` 등에서 사용되는 실패 처리 패턴을 준수하여 구현했습니다.

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다