### PR TITLE
[Fix] 식단 데이터 로드 실패 시 로딩/새로고침 인디케이터가 사라지지 않는 문제 수정

### DIFF
--- a/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningViewModel.kt
+++ b/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningViewModel.kt
@@ -133,6 +133,8 @@ class DiningViewModel @Inject constructor(
                     }
                     .onFailure {
                         _dining.value = listOf()
+                        _isLoading.value = false
+                        _isDiningRefreshing.value = false
                     }
             }
         }


### PR DESCRIPTION
이슈 번호: #16

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
식단 데이터(`getDining()`) 로드 실패 시 로딩 스피너(`_isLoading`) 및 Pull-to-Refresh 인디케이터(`_isDiningRefreshing`)가 무한히 표시되는 문제를 해결했습니다.

`DiningViewModel`의 `getDining()` 함수에서 네트워크 오류 발생 시 `onFailure` 블록에 `_isLoading.value = false`와 `_isDiningRefreshing.value = false` 초기화 로직이 누락되어, 실패 후에도 UI 상태가 정상적으로 복구되지 않고 재시도가 차단되는 원인이었습니다.

`onSuccess` 블록의 구현을 참고하여 `onFailure` 블록에 해당 상태 변수들을 `false`로 리셋하는 코드를 추가하여, 실패 경로에서도 UI 상태가 일관성 있게 관리되도록 수정했습니다.

수정 후, 네트워크 오류 발생 시 로딩/새로고침 인디케이터가 정상적으로 사라지고, 날짜 변경이나 Pull-to-Refresh를 통한 재시도가 가능해집니다.

### 논의 사항
(없음)

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다