### PR TITLE
[Fix] 동아리 QnA 로드 실패 시 로딩 인디케이터가 사라지지 않는 문제

### DIFF
--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailViewModel.kt
@@ -32,6 +32,7 @@ import `in`.koreatech.koin.feature.club.model.toParcelizeClubRecruitment
 import `in`.koreatech.koin.feature.club.navigation.CLUB_ID
 import `in`.koreatech.koin.feature.club.type.EventSearchType
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -148,6 +149,10 @@ class ClubDetailViewModel @Inject constructor(
                         showQnasProgressBar = false
                     )
                 }
+            }.onFailure { e ->
+                if (e is CancellationException) throw e
+                reduce { state.copy(isLoading = false, showQnasProgressBar = false) }
+                postSideEffect(ClubDetailSideEffect.UnknownError)
             }
         }
     }


### PR DESCRIPTION
## PR 개요
이슈 번호: #8

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
`feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailViewModel.kt` 파일에서 `ClubDetailViewModel.loadClubQnas()` 함수에 `onFailure` 핸들링 로직을 추가했습니다.

기존에는 `ClubDetailViewModel.loadClubQnas()` 함수에서 `getClubQnasUseCase` 호출 시 `.onSuccess` 블록만 구현되어 있었고, QnA 목록 로드 실패 시 `isLoading` 및 `showQnasProgressBar` 상태 플래그가 `true`로 고정되어 로딩 인디케이터가 화면에서 사라지지 않는 문제가 발생했습니다.

이번 수정으로 `onFailure` 블록을 추가하여 코루틴 취소 예외를 올바르게 처리하고, 실패 시 로딩 플래그들을 `false`로 초기화하여 UI 상태를 안정적으로 복구합니다. 또한, `ClubDetailSideEffect.UnknownError`를 발생시켜 사용자에게 일반 오류 메시지를 표시하도록 개선했습니다. 이는 `loadClubDetails()`, `loadClubRecruitment()`, `loadClubEvents()` 등 동일 ViewModel 내 다른 로딩 함수들의 기존 패턴과 일관성을 유지합니다.

### 논의 사항
- `ClubDetailSideEffect.UnknownError`를 재사용하여 새 SideEffect 타입을 추가하지 않았습니다. 이는 `ClubDetail.kt` 파일의 `when (sideEffect)` 구문이 exhaustive 처리를 유지하도록 하기 위함입니다.
- `ClubRepositoryImpl.getClubQnas()` 함수에서 HTTP 404 오류가 `KoinClubException.ClubNotFoundException`으로 매핑되지 않으므로, 해당 예외에 대한 분기는 추가하지 않았습니다.

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다