### PR TITLE
[Fix] 메인 배너 무한 로딩 오류 수정

### DIFF
--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerViewModel.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerViewModel.kt
@@ -12,10 +12,12 @@ import `in`.koreatech.koin.feature.banner.model.BannerState
 import `in`.koreatech.koin.feature.banner.model.toLocalBanner
 import javax.inject.Inject
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flow
@@ -52,12 +54,18 @@ class BannerViewModel @Inject constructor(
         ).filterNotNull()
 
     private fun fetchBanners() = viewModelScope.launch {
-        getBannersByCategoryUseCase(MAIN_BANNER_CATEGORY).collectLatest {
-            _bannerState.value = _bannerState.value.copy(
-                bannerList = it.map { banner -> banner.toLocalBanner() }.toImmutableList(),
-                isLoading = false
-            )
-        }
+        getBannersByCategoryUseCase(MAIN_BANNER_CATEGORY)
+            .catch {
+                if (it is CancellationException) throw it
+                Timber.e(it)
+                _bannerState.value = _bannerState.value.copy(isLoading = false)
+            }
+            .collectLatest {
+                _bannerState.value = _bannerState.value.copy(
+                    bannerList = it.map { banner -> banner.toLocalBanner() }.toImmutableList(),
+                    isLoading = false
+                )
+            }
     }
 
     private fun fetchCurrentVersionCode() = viewModelScope.launch {

--- a/reviews/completeness.md
+++ b/reviews/completeness.md
@@ -1,0 +1,31 @@
+# Completeness 리뷰
+
+## Summary
+PLAN.md가 요구한 단일 파일 수정이 정확히 수행되었으며, IMPL.md에 기재된 변경 내용과 실제 git diff가 완전히 일치합니다. PLAN.md 범위 외 파일 수정은 없습니다.
+
+## 문제점
+
+없음.
+
+---
+
+## 항목별 검증 결과
+
+| 검증 항목 | 기준 | 결과 |
+|---|---|---|
+| PLAN.md 지정 파일 변경 여부 | `BannerViewModel.kt` 1개 파일 수정 | ✅ git diff에 동일 파일 1개만 존재 |
+| IMPL.md 기재 파일 vs git diff | `BannerViewModel.kt` | ✅ 완전 일치 (할루시네이션 없음) |
+| `.catch {}` 핸들러 추가 | `fetchBanners()` 내 `.catch { ... }` 삽입 | ✅ line 58–62에 구현 완료 |
+| `isLoading = false` 에러 경로 | `.catch` 블록 내 `copy(isLoading = false)` | ✅ line 61에 존재 |
+| `kotlinx.coroutines.flow.catch` import | PLAN.md 명시 추가 필요 | ✅ line 20에 추가됨 |
+| 성공 경로 유지 | `collectLatest { ... isLoading = false }` | ✅ line 63–68에 유지됨 |
+| PLAN.md 범위 외 파일 수정 | 없어야 함 | ✅ 단일 파일만 변경됨 |
+| 신규 파일 생성 | IMPL.md: 없음 | ✅ git diff에 신규 파일 없음 |
+
+**추가 사항 (범위 내 개선)**: IMPL.md는 CODE_REVIEW.md 피드백을 반영해 `CancellationException` 재던짐(`import kotlinx.coroutines.CancellationException` + `if (it is CancellationException) throw it`)을 추가했습니다. 이는 PLAN.md가 명시적으로 금지한 변경이 아니며, 동일 파일 내 개선으로 범위 위반에 해당하지 않습니다.
+
+---
+
+CRITICAL: 0
+MAJOR: 0
+MINOR: 0

--- a/reviews/compose.md
+++ b/reviews/compose.md
@@ -1,0 +1,21 @@
+# Compose 리뷰
+
+## Summary
+
+PLAN.md 범위(`BannerViewModel.kt`)의 변경 사항에서 Compose UI 관점의 문제는 발견되지 않았습니다. `.catch { }` 핸들러 추가는 `BannerState.isLoading = false` 전이를 보장하여 무한 로딩 상태를 올바르게 해소합니다.
+
+## 문제점
+
+해당 없음.
+
+변경된 코드(`BannerViewModel.kt:56-69`)를 기준으로 검토한 결과:
+
+- **State 전이 정확성**: `.catch` 블록에서 `_bannerState.value = _bannerState.value.copy(isLoading = false)` 호출이 올바르게 배치되어, 예외 발생 시 `BannerActivity`의 `if (!uiState.isLoading)` 분기가 정상 진입됩니다.
+- **컴포지션 중 부수효과**: 변경된 코드 자체는 Compose 컴포지션 밖(ViewModel `launch` 블록)에서만 실행되므로 composition-time side effect 문제 없음.
+- **StateFlow 수집 방식**: 수집부(`BannerActivity.kt:39` — `collectAsState()`)는 변경 범위 밖이며, IMPL.md에서 이미 `finishActivity()` composition-time 호출 문제와 함께 별도 이슈로 추적 권장으로 명시되어 있어 이번 리뷰 대상 외.
+
+---
+
+CRITICAL: 0
+MAJOR: 0
+MINOR: 0

--- a/reviews/kotlin.md
+++ b/reviews/kotlin.md
@@ -1,0 +1,55 @@
+관련 파일 확인이 완료되었습니다. 검토를 작성합니다.
+
+---
+
+# Kotlin 리뷰
+
+## Summary
+
+PLAN.md 범위 내 변경 코드(`fetchBanners()` `.catch {}` 추가 및 import 2건)를 Kotlin·아키텍처 관점에서 검토한 결과, 실제 버그·아키텍처 위반·런타임 예외 가능성에 해당하는 CRITICAL 또는 MAJOR 이슈는 발견되지 않았습니다.
+
+## 적합성 검증
+
+### `.catch {}` 배치 위치
+
+```kotlin
+getBannersByCategoryUseCase(MAIN_BANNER_CATEGORY)
+    .catch { ... }       // upstream 예외 포착 ← 올바른 위치
+    .collectLatest { ... }
+```
+
+`.catch`는 upstream(소스 Flow)에서 발생한 예외만 포착합니다. `collectLatest` 앞에 배치되어 있으므로 소스 Flow의 예외를 올바르게 처리합니다.
+
+### `CancellationException` 재던짐
+
+```kotlin
+.catch {
+    if (it is CancellationException) throw it
+    ...
+}
+```
+
+`kotlinx.coroutines.flow.catch`는 `CancellationException`을 포함한 모든 `Throwable`을 포착합니다. 재던짐을 생략하면 `viewModelScope` 취소 신호가 소비되어 코루틴이 정상 종료되지 않을 수 있습니다. 명시적 재던짐은 구조적 동시성을 보장하는 올바른 패턴이며, 프로젝트 전반(`runCatching` 사용처)에서 동일하게 요구하는 규칙과 일치합니다.
+
+### Import 추가
+
+| import | 평가 |
+|--------|------|
+| `kotlinx.coroutines.CancellationException` | ✅ `kotlin.coroutines.cancellation.CancellationException`의 typealias, Android 표준 사용 |
+| `kotlinx.coroutines.flow.catch` | ✅ Flow 확장 함수 올바른 임포트 |
+
+### 상태 업데이트 패턴
+
+`.catch {}` 내 `_bannerState.value = _bannerState.value.copy(isLoading = false)`는 파일 전체(line 64–67, 73–75)에서 이미 사용 중인 기존 패턴입니다. 이번 변경이 새로 도입한 패턴이 아니므로 PLAN.md 범위에서 별도 이슈로 올리지 않습니다.
+
+## 문제점
+
+없음.
+
+---
+
+```
+CRITICAL: 0
+MAJOR: 0
+MINOR: 0
+```

--- a/reviews/security.md
+++ b/reviews/security.md
@@ -1,0 +1,25 @@
+# Security 리뷰
+
+## Summary
+
+PLAN.md 범위인 `BannerViewModel.kt`의 변경 사항을 보안 관점에서 검토했습니다. 신규 도입된 코드는 `.catch {}` 블록 추가와 `import` 두 줄이며, 이 범위 내에서 실제 exploit 가능하거나 민감 정보가 유출되는 보안 취약점은 발견되지 않았습니다.
+
+## 문제점
+
+해당 없음.
+
+---
+
+**검토 근거**
+
+| 항목 | 결과 |
+|------|------|
+| 하드코딩 시크릿 | `MAIN_BANNER_CATEGORY = 1` — 공개 카테고리 식별자, 시크릿 아님 |
+| `Timber.e(it)` 민감 데이터 로깅 | 배너 조회 엔드포인트는 공개 API이며 응답에 PII·토큰 미포함. Timber는 release 빌드에서 Tree 미식재 시 출력 없음. 기존 line 77 패턴과 동일 |
+| `CancellationException` 처리 | 적절히 재던짐 — 코루틴 취소 신호 누수 없음 |
+| 인증 토큰 처리 | `.catch` 블록은 상태 초기화만 수행, 토큰 노출 경로 없음 |
+| 기타 (Intent hijacking, WebView, SQL 등) | 변경 범위 외 |
+
+CRITICAL: 0  
+MAJOR: 0  
+MINOR: 0

--- a/reviews/sonarqube.md
+++ b/reviews/sonarqube.md
@@ -1,0 +1,62 @@
+SonarQube MCP 권한이 거부되어 있습니다. 알려진 SonarQube Kotlin 규칙으로 스니펫을 수동 분석합니다.
+
+---
+
+# SonarQube 리뷰
+
+## Summary
+
+SonarQube MCP 서버에 대한 권한이 거부되어 프로젝트/Quality Gate 조회를 수행할 수 없었습니다. 변경 코드 스니펫을 SonarQube 공식 Kotlin 규칙 기준으로 직접 분석하여 대체합니다.
+
+## Quality Gate
+
+- 상태: NOT_CONFIGURED (권한 거부로 조회 불가)
+
+---
+
+## 문제점
+
+### [MINOR] 1. `Flow.catch` 내 `CancellationException` 재던짐 분기 — 도달 불가 코드 (kotlin:S2583)
+
+파일 경로: `feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerViewModel.kt:58-59`
+
+#### 리뷰 사항
+
+```kotlin
+.catch {
+    if (it is CancellationException) throw it   // ← 이 분기에 도달하지 않음
+    Timber.e(it)
+    _bannerState.value = _bannerState.value.copy(isLoading = false)
+}
+```
+
+`kotlinx.coroutines` **1.5.0** 이상에서 `Flow.catch` 연산자는 `CancellationException`을 투명하게 통과시킵니다(catch 하지 않음). 따라서 `it is CancellationException` 조건은 런타임에서 항상 `false`이며 해당 분기에 도달하지 않습니다. SonarQube는 이를 `kotlin:S2583` ("Conditions should not always evaluate to 'true' or 'false'") 또는 `kotlin:S6619` ("CancellationException caught by Flow's catch should be re-thrown") 규칙으로 데드 코드 경고를 발행할 수 있습니다.
+
+#### 수정 방향
+
+`CancellationException` 투명성이 보장된 coroutines 버전을 사용 중이라면 해당 분기를 제거하여 코드 노이즈를 줄이는 것이 좋습니다. 단, 프로젝트의 coroutines 최소 지원 버전이 1.4.x 이하라면 방어적 코드로 유지하는 것이 타당합니다.
+
+```kotlin
+// coroutines 1.5.0+ 환경: 분기 제거
+.catch {
+    Timber.e(it)
+    _bannerState.value = _bannerState.value.copy(isLoading = false)
+}
+```
+
+---
+
+## 변경 범위 내 추가 검토 결과
+
+| 검토 항목 | 결과 |
+|---|---|
+| Cognitive Complexity (`fetchBanners`) | 이슈 없음 — 추가된 분기 포함 복잡도 ≤ 3 |
+| 코드 중복 | 이슈 없음 — `.copy(isLoading = false)` 2회 반복이지만 중복 임계(10줄 이상) 미달 |
+| 보안 핫스팟 | 이슈 없음 — 외부 입력 노출·로그 민감정보 없음 |
+| Coverage 하락 | 측정 불가 (SonarQube 미접근) |
+
+---
+
+**CRITICAL: 0**
+**MAJOR: 0**
+**MINOR: 1**


### PR DESCRIPTION
## PR 개요
이슈 번호: #10

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [ ] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- **문제점**: 메인 화면의 배너 영역이 네트워크 오류 발생 시 무한 로딩 상태로 고착되는 현상.
- **근본 원인**: `BannerState.isLoading`의 기본값이 `true`로 설정되어 있으며, `fetchBanners()` 함수에서 Flow 수집 중 예외 발생 시 `.catch` 핸들러가 없어 `isLoading`이 `false`로 전환되지 않기 때문입니다.
- **해결 방안**:
    1. `feature/banner/ui/BannerViewModel.kt`의 `fetchBanners()` 함수에 `.catch` 핸들러를 추가하여 네트워크 오류 등 예외 발생 시 `isLoading` 값을 `false`로 설정합니다.
    2. 코드 리뷰에서 제기된 MAJOR 피드백인 `CancellationException`의 정상적인 상위 전파를 위해, `.catch` 블록 내에서 `CancellationException`은 재던지고, 그 외 예외는 `Timber`를 통해 로깅하도록 수정했습니다.
    3. MINOR 피드백인 단일 문자 파라미터명(`e` → `it`)도 반영했습니다.
    4. `reviews/` 디렉토리의 관련 문서 업데이트도 포함되었습니다.

### 논의 사항
- `BannerActivity.kt` 내 `finishActivity()` 직접 호출 관련 MINOR 이슈는 본 PR의 범위를 벗어나므로, 별도 이슈로 관리하는 것을 권장합니다.

### 스크린샷
- 없음

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다