### PR TITLE
[Fix] SemesterViewModel에서 학기 삭제 실패 시 onFailure 처리 누락 수정

### DIFF
--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/viewmodel/SemesterViewModel.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/viewmodel/SemesterViewModel.kt
@@ -20,6 +20,7 @@ import `in`.koreatech.koin.feature.timetable.model.SemesterModel
 import `in`.koreatech.koin.feature.timetable.state.SemesterSideEffect
 import `in`.koreatech.koin.feature.timetable.utils.toSemesterModel
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -241,6 +242,10 @@ class SemesterViewModel @Inject constructor(
                         updateUserTimetableFrames(
                             screenState.value.userTimetableFrames - semester
                         )
+                    }.onFailure {
+                        if (it is CancellationException) throw it
+                        val errorMessage = it.message ?: SEMESTER_DELETE_FAILURE_MESSAGE
+                        _sideEffect.value = SemesterSideEffect.Toast(errorMessage)
                     }
                 } else {
                     addSemesterUseCase(semester.toSemester()).onSuccess { addedFrame ->
@@ -248,9 +253,9 @@ class SemesterViewModel @Inject constructor(
                             (screenState.value.userTimetableFrames + (semester to listOf(addedFrame))).toSortedMap()
                         )
                     }.onFailure {
-                        it.message?.let { errorMessage ->
-                            _sideEffect.value = SemesterSideEffect.Toast(errorMessage)
-                        }
+                        if (it is CancellationException) throw it
+                        val errorMessage = it.message ?: SEMESTER_ADD_FAILURE_MESSAGE
+                        _sideEffect.value = SemesterSideEffect.Toast(errorMessage)
                     }
                 }
             }
@@ -422,6 +427,11 @@ class SemesterViewModel @Inject constructor(
         _currentTimetableSemester.value = ""
         _currentTimetableName.value = ""
         _currentTimetableId.value = -1
+    }
+
+    companion object {
+        private const val SEMESTER_DELETE_FAILURE_MESSAGE = "학기 삭제에 실패했습니다."
+        private const val SEMESTER_ADD_FAILURE_MESSAGE = "학기 추가에 실패했습니다."
     }
 }
 

--- a/reviews/completeness.md
+++ b/reviews/completeness.md
@@ -1,0 +1,45 @@
+모든 항목을 확인했습니다. 결과를 정리합니다.
+
+---
+
+# Completeness 리뷰
+
+## Summary
+PLAN.md가 요구한 단일 파일 수정이 정확히 반영되었고, IMPL.md에 기재된 모든 변경사항이 git diff에 존재한다. 범위 외 파일 수정 없음.
+
+## 검증 결과
+
+### PLAN.md 대상 파일 포함 여부
+| PLAN.md 수정 대상 | git diff 존재 여부 |
+|---|---|
+| `feature/timetable/.../SemesterViewModel.kt` | ✅ 존재 |
+
+### IMPL.md 정합성
+| IMPL.md 기재 항목 | git diff 대응 여부 |
+|---|---|
+| `CancellationException` import 추가 | ✅ line 23 |
+| `deleteSemesterUseCase.onFailure` 블록 추가 | ✅ line 245–249 |
+| `addSemesterUseCase.onFailure` 패턴 대칭화 | ✅ line 255–258 |
+| `SEMESTER_DELETE_FAILURE_MESSAGE` 상수 추가 | ✅ companion object line 433 |
+| `SEMESTER_ADD_FAILURE_MESSAGE` 상수 추가 | ✅ companion object line 434 |
+
+### 완료 조건 충족 여부
+| PLAN.md 완료 조건 | 충족 여부 |
+|---|---|
+| `deleteSemesterUseCase` 체인에 `.onFailure` 추가 | ✅ |
+| `onFailure`에서 Toast sideEffect emit | ✅ (`_sideEffect.value = SemesterSideEffect.Toast(errorMessage)`) |
+| `addSemesterUseCase`와 동일 패턴 적용 | ✅ |
+| `ktlintCheck` 통과 | IMPL.md에 ✅ 기재 (직접 실행 불가, 검증 생략) |
+
+### 범위 외 파일 수정 여부
+변경된 파일은 `SemesterViewModel.kt` 단 1개이며, PLAN.md 명시 대상과 일치함. 범위 외 수정 없음.
+
+## 문제점
+
+없음.
+
+---
+
+CRITICAL: 0
+MAJOR: 0
+MINOR: 0

--- a/reviews/compose.md
+++ b/reviews/compose.md
@@ -1,0 +1,39 @@
+충분한 컨텍스트를 확보했습니다. 리뷰를 작성합니다.
+
+---
+
+# Compose 리뷰
+
+## Summary
+
+이번 PR의 수정 범위(`SemesterViewModel.kt`)는 순수 ViewModel 로직 변경이며, Compose UI 레이어에서 `_sideEffect`(`MutableStateFlow`) 소비 구조는 이미 `Toast` 분기를 처리하고 있어 신규 Compose 버그 없이 올바르게 동작합니다.
+
+## 문제점
+
+### [MINOR] 1. `_sideEffect` StateFlow 중복 이벤트 소실 가능성
+
+파일 경로: `feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/viewmodel/SemesterViewModel.kt:81`  
+소비처: `koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableSemesterActivity.kt:190`
+
+#### 리뷰 사항
+
+`_sideEffect`가 `MutableStateFlow<SemesterSideEffect>`이고, UI 쪽에서는 `LaunchedEffect(sideEffect)`로 소비합니다. `StateFlow`는 연속으로 같은 값이 emit되면 두 번째 이후를 무시(deduplication)합니다.
+
+`updateUserSemesters()` 내 `forEach`에서 학기 A, B 삭제가 연달아 실패할 경우:
+
+```
+delete A 실패 → _sideEffect = Toast("학기 삭제에 실패했습니다.")
+delete B 실패 → _sideEffect = Toast("학기 삭제에 실패했습니다.") // 동일값, StateFlow가 무시
+```
+
+UI의 `LaunchedEffect`가 재실행되지 않아 두 번째 실패 알림이 사용자에게 전달되지 않습니다.
+
+#### 수정 방향
+
+IMPL.md에서 이미 이 구조적 한계를 인지하고 이번 PR 범위 밖으로 명시했으므로 즉각 수정 대상은 아닙니다. 향후 `_sideEffect`를 `Channel(BUFFERED)` 또는 `SharedFlow(replay=0)`로 교체하고, UI 소비처를 `LaunchedEffect` 대신 `collectAsStateWithLifecycle`+`collect`로 전환하는 별도 리팩터링 PR에서 해결하는 것이 적합합니다.
+
+---
+
+CRITICAL: 0  
+MAJOR: 0  
+MINOR: 1

--- a/reviews/kotlin.md
+++ b/reviews/kotlin.md
@@ -1,0 +1,27 @@
+수정된 파일을 직접 확인했습니다. 수정 범위 내에서 Kotlin/Architecture 이슈를 검토합니다.
+
+---
+
+# Kotlin 리뷰
+
+## Summary
+
+PLAN.md에 명시된 수정 범위(`updateUserSemesters()`의 `deleteSemesterUseCase` onFailure 추가 및 `addSemesterUseCase` 대칭화, 상수 추출)에서 Kotlin·아키텍처 위반은 발견되지 않음. 구현이 프로젝트 컨벤션을 정확히 따르고 있음.
+
+## 문제점
+
+해당 없음.
+
+수정된 코드 블록(line 245–259, companion object)에 대한 검토 결과:
+
+- `Result<T>.onFailure` 내부에서 `if (it is CancellationException) throw it` 재던짐: `Result.onFailure`는 `inline` 함수이므로 `throw`가 `viewModelScope.launch { ... }` 코루틴 바디로 정상 전파됨 ✅
+- `it.message ?: SEMESTER_DELETE_FAILURE_MESSAGE` 폴백 패턴: 기존 `it.message?.let { }` 방식(null 시 Toast 미출력)의 버그를 올바르게 수정 ✅
+- `companion object`에 `private const val`로 상수 추출: 가시성·위치 모두 적절 ✅
+- `import kotlinx.coroutines.CancellationException` 추가: 백틱 이스케이프 불필요(예약어 아님), 임포트 그룹 순서도 Android Studio 기본 컨벤션에 부합 ✅
+- ViewModel → UseCase 호출 구조: Repository 직접 호출 없음 ✅
+
+---
+
+CRITICAL: 0
+MAJOR: 0
+MINOR: 0

--- a/reviews/security.md
+++ b/reviews/security.md
@@ -1,0 +1,28 @@
+# Security 리뷰
+
+## Summary
+
+이번 변경(PLAN.md 범위: `SemesterViewModel.kt`의 `deleteSemesterUseCase` `onFailure` 추가 및 `addSemesterUseCase` 대칭화)에서 새롭게 도입된 보안 취약점은 발견되지 않았습니다.
+
+## 검토 결과
+
+### 변경 범위 내 주요 항목 점검
+
+| 항목 | 결과 |
+|---|---|
+| 하드코딩 시크릿 / 토큰 | 없음. 추가된 `companion object` 상수는 한국어 UI 메시지 전용 |
+| 민감 데이터 로깅 | diff에 새 `Timber.d` 추가 없음 |
+| `it.message` Toast 노출 | 기존 `addSemesterUseCase.onFailure` 패턴과 동일. `HttpException.message`는 HTTP 상태 줄(예: `HTTP 404 Not Found`) 수준이며 PII 포함 없음 |
+| `CancellationException` 재던짐 | 코루틴 안전 처리로 보안 이점(오탐 Toast로 인한 상태 혼선 방지) 있음 |
+| 새로운 네트워크·DB·파일 접근 | 없음 |
+| 새로운 Intent / DeepLink 처리 | 없음 |
+
+## 문제점
+
+이번 수정 범위 내에서 exploit 가능하거나 민감 정보가 유출되는 보안 이슈는 없습니다.
+
+---
+
+CRITICAL: 0
+MAJOR: 0
+MINOR: 0

--- a/reviews/sonarqube.md
+++ b/reviews/sonarqube.md
@@ -1,0 +1,28 @@
+SonarQube MCP 도구에 대한 권한이 거부되었습니다. 규칙 5에 따라 결과를 작성합니다.
+
+---
+
+# SonarQube 리뷰
+
+## Summary
+
+SonarQube MCP 도구 권한이 거부되어 프로젝트 조회 및 스니펫 분석 모두 실행 불가 — **SonarQube 미설정 (MCP 도구 접근 불가)**으로 처리합니다. 이슈 0건.
+
+## Quality Gate
+
+- 상태: **NOT_CONFIGURED** (MCP 접근 권한 없음)
+- 실패 조건: 조회 불가
+
+## 문제점
+
+해당 없음 — SonarQube 스캔 결과 없음.
+
+---
+
+```
+CRITICAL: 0
+MAJOR:    0
+MINOR:    0
+```
+
+> **참고**: SonarQube 분석을 실행하려면 `mcp__sonarqube__search_my_sonarqube_projects` 및 `mcp__sonarqube__analyze_code_snippet` 도구 권한을 허용해 주세요. 권한 부여 후 재실행하면 Quality Gate, 보안 핫스팟, 중복 코드, 인지 복잡도 지표를 실제 스캔 결과 기준으로 보고합니다.


### PR DESCRIPTION
## PR 개요
이슈 번호: #11

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [ ] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
`SemesterViewModel.updateUserSemesters()`에서 학기 삭제(`deleteSemesterUseCase`) 실패 시 `onFailure` 처리 누락으로 인해 사용자에게 피드백이 제공되지 않고 앱 상태와 서버 상태 간 불일치가 발생하는 버그를 수정했습니다.

**문제점:**
`updateUserSemesters()` 함수 내 `deleteSemesterUseCase` 호출 체인에 `.onFailure { }` 블록이 누락되어, 삭제 실패 시 별도의 사용자 피드백이 없었고, 동일 함수 내 `addSemesterUseCase`와는 처리 방식이 불일치했습니다.

**해결 방안:**
1.  `deleteSemesterUseCase` 호출 체인에 `.onFailure` 블록을 추가했습니다.
2.  [MAJOR] `CancellationException` 발생 시에는 Toast 메시지 대신 예외를 다시 던지도록 처리하여 코루틴 취소 시 발생하는 오인된 Toast 알림을 방지했습니다.
3.  `addSemesterUseCase`의 `onFailure` 로직도 `CancellationException` 처리 및 null 폴백 상수(`SEMESTER_ADD_FAILURE_MESSAGE`) 사용으로 통일하여, 추가/삭제 분기 간 대칭성을 확보했습니다.
4.  `companion object`에 `SEMESTER_ADD_FAILURE_MESSAGE = "학기 추가에 실패했습니다."` 상수 및 `import kotlinx.coroutines.CancellationException`을 추가했습니다.

## 논의 사항
- `_sideEffect`가 `MutableStateFlow`를 사용하므로, 여러 번의 삭제 실패가 연속적으로 발생할 경우 동일한 Toast 메시지가 중복 emit되지 않는 구조적 한계가 있습니다. 이 부분은 `_sideEffect`를 `Channel` 또는 `SharedFlow(replay=0)`로 교체하는 별도 리팩토링을 통해 개선될 수 있으나, 본 PR의 범위를 벗어납니다.

### 스크린샷
(스크린샷이 제공되지 않았습니다.)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

## Git Log (origin/develop..HEAD)
9c054bfa4 fix: Handle semester deletion failure in ViewModel

## Git Diff Stat
 .../timetable/viewmodel/SemesterViewModel.kt       | 16 ++++++--
 reviews/completeness.md                            | 45 ++++++++++++++++++++++
 reviews/compose.md                                 | 39 +++++++++++++++++++
 reviews/kotlin.md                                  | 27 +++++++++++++
 reviews/security.md                                | 28 ++++++++++++++
 reviews/sonarqube.md                               | 28 ++++++++++++++
 6 files changed, 180 insertions(+), 3 deletions(-)