### PR TITLE
[Fix] 게시글 키워드 알림 중복 등록 이슈 수정

### DIFF
--- a/feature/article/src/main/java/in/koreatech/koin/feature/article/ui/keyword/ArticleKeywordViewModel.kt
+++ b/feature/article/src/main/java/in/koreatech/koin/feature/article/ui/keyword/ArticleKeywordViewModel.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
@@ -40,6 +41,9 @@ class ArticleKeywordViewModel @Inject constructor(
     private val deleteNotificationSubscriptionUseCase: DeleteNotificationSubscriptionUseCase,
     getUserStatusUseCase: GetUserStatusUseCase
 ) : BaseViewModel() {
+    private val addingKeywords = mutableSetOf<String>()
+    private val deletingKeywords = mutableSetOf<String>()
+
     val user: StateFlow<User> =
         getUserStatusUseCase()
             .stateIn(viewModelScope, SharingStarted.Eagerly, User.Anonymous)
@@ -111,12 +115,16 @@ class ArticleKeywordViewModel @Inject constructor(
             return
         }
 
+        if (!addingKeywords.add(trimmedKeyword)) return
+
         articleRepository.saveKeyword(trimmedKeyword).onStart {
             _keywordAddUiState.emit(KeywordAddUiState.Loading)
         }.onEach {
             _keywordAddUiState.emit(KeywordAddUiState.Success(trimmedKeyword))
         }.catch {
             _keywordAddUiState.emit(KeywordAddUiState.Error)
+        }.onCompletion {
+            addingKeywords.remove(trimmedKeyword)
         }.launchIn(viewModelScope)
     }
 
@@ -145,10 +153,14 @@ class ArticleKeywordViewModel @Inject constructor(
     }
 
     fun deleteKeyword(keyword: String) {
+        if (!deletingKeywords.add(keyword)) return
+
         articleRepository.deleteKeyword(keyword).onEach {
             _keywordAddUiState.emit(KeywordAddUiState.Success(keyword))
         }.catch {
             _keywordAddUiState.emit(KeywordAddUiState.Error)
+        }.onCompletion {
+            deletingKeywords.remove(keyword)
         }.launchIn(viewModelScope)
     }
 


### PR DESCRIPTION
## PR 개요
이슈 번호: #37

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
ArticleKeywordViewModel의 게시글 키워드 알림 중복 등록(따닥) 이슈를 키워드 단위 in-flight 가드로 해결했습니다. `addingKeywords`, `deletingKeywords` mutableSetOf를 추가하여 동일 키워드의 API 중복 호출을 차단하고, `onCompletion`으로 성공/실패/취소 시 정확히 해제합니다.

**주요 구현 내용**:
- **`addingKeywords` 필드**: `mutableSetOf<String>()` — 추가 중인 키워드 추적
- **`deletingKeywords` 필드**: `mutableSetOf<String>()` — 삭제 중인 키워드 추적
- **`addKeyword()` 가드**: `if (!addingKeywords.add(trimmedKeyword)) return` — 동일 키워드 중복 호출 차단
- **`addKeyword()` 해제**: `.onCompletion { addingKeywords.remove(trimmedKeyword) }` — 성공/실패/취소 시 자동 정리
- **`deleteKeyword()` 가드**: `if (!deletingKeywords.add(keyword)) return` — 동일 키워드 중복 호출 차단
- **`deleteKeyword()` 해제**: `.onCompletion { deletingKeywords.remove(keyword) }` — 성공/실패/취소 시 자동 정리

## 논의 사항
- Repository 직접 호출 → UseCase 리팩토링 (CODE_REVIEW.md 참고)
  - 범위: PLAN.md 범위 밖 (domain 모듈 신규 파일 생성 필요)
  - 조치: 별도 리팩토링 PR로 처리 필요

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다