### PR TITLE
[Fix] 회원가입 실패 시 에러 피드백 제공

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
@@ -19,6 +19,7 @@ import `in`.koreatech.koin.domain.model.user.Graduated
 import `in`.koreatech.koin.domain.repository.SignupRepository
 import `in`.koreatech.koin.domain.util.ext.toSHA256
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 import retrofit2.HttpException
 
 class SignupRepositoryImpl @Inject constructor(
@@ -131,7 +132,12 @@ class SignupRepositoryImpl @Inject constructor(
             )
             Result.success(Unit)
         } catch (e: HttpException) {
-            Result.failure(e)
+            val message = runCatching { e.getErrorResponse().message }.getOrNull().orEmpty()
+            Result.failure(Throwable(message))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            Result.failure(t)
         }
     }
 
@@ -176,7 +182,12 @@ class SignupRepositoryImpl @Inject constructor(
             )
             Result.success(Unit)
         } catch (e: HttpException) {
-            Result.failure(e)
+            val message = runCatching { e.getErrorResponse().message }.getOrNull().orEmpty()
+            Result.failure(Throwable(message))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            Result.failure(t)
         }
     }
 }

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/general/SignUpGeneralSideEffect.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/general/SignUpGeneralSideEffect.kt
@@ -2,5 +2,5 @@ package `in`.koreatech.koin.feature.user.ui.signup.userinfo.general
 
 sealed class SignUpGeneralSideEffect {
     data object SignUpSuccess : SignUpGeneralSideEffect()
-    data object SignUpFailure : SignUpGeneralSideEffect()
+    data class SignUpFailure(val message: String) : SignUpGeneralSideEffect()
 }

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/general/SignUpGeneralUserInfo.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/general/SignUpGeneralUserInfo.kt
@@ -1,5 +1,7 @@
 package `in`.koreatech.koin.feature.user.ui.signup.userinfo.general
 
+import android.content.Context
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
@@ -22,6 +24,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -54,10 +57,12 @@ fun SignUpGeneralUserInfo(
     navigateToNextScreen: () -> Unit
 ) {
     val uiState by viewModel.collectAsState()
+    val context = LocalContext.current
 
     viewModel.collectSideEffect {
         handleSideEffect(
             sideEffect = it,
+            context = context,
             navigateToNextScreen = navigateToNextScreen
         )
     }
@@ -406,6 +411,7 @@ private fun SignUpGeneralUserInfoNickNameEmailStep(
 
 private fun handleSideEffect(
     sideEffect: SignUpGeneralSideEffect,
+    context: Context,
     navigateToNextScreen: () -> Unit
 ) {
     when (sideEffect) {
@@ -419,7 +425,10 @@ private fun handleSideEffect(
         }
 
         is SignUpGeneralSideEffect.SignUpFailure -> {
-            // TODO: Handle sign up failure
+            val message = sideEffect.message.ifBlank {
+                context.getString(R.string.sign_up_user_info_sign_up_failed)
+            }
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         }
     }
 }

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/general/SignUpGeneralViewModel.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/general/SignUpGeneralViewModel.kt
@@ -190,7 +190,7 @@ class SignUpGeneralViewModel @Inject constructor(
         ).onSuccess {
             postSideEffect(SignUpGeneralSideEffect.SignUpSuccess)
         }.onFailure {
-            postSideEffect(SignUpGeneralSideEffect.SignUpFailure)
+            postSideEffect(SignUpGeneralSideEffect.SignUpFailure(it.message ?: ""))
         }
     }
 }

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/student/SignUpStudentSideEffect.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/student/SignUpStudentSideEffect.kt
@@ -2,5 +2,5 @@ package `in`.koreatech.koin.feature.user.ui.signup.userinfo.student
 
 sealed class SignUpStudentSideEffect {
     data object SignUpSuccess : SignUpStudentSideEffect()
-    data object SignUpFailure : SignUpStudentSideEffect()
+    data class SignUpFailure(val message: String) : SignUpStudentSideEffect()
 }

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/student/SignUpStudentUserInfo.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/student/SignUpStudentUserInfo.kt
@@ -1,5 +1,7 @@
 package `in`.koreatech.koin.feature.user.ui.signup.userinfo.student
 
+import android.content.Context
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
@@ -22,6 +24,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -58,10 +61,12 @@ fun SignUpStudentUserInfo(
     navigateToNextScreen: () -> Unit
 ) {
     val uiState by viewModel.collectAsState()
+    val context = LocalContext.current
 
     viewModel.collectSideEffect {
         handleSideEffect(
             sideEffect = it,
+            context = context,
             navigateToNextScreen = navigateToNextScreen
         )
     }
@@ -495,6 +500,7 @@ private fun SignUpStudentUserInfoNickNameEmailStep(
 
 private fun handleSideEffect(
     sideEffect: SignUpStudentSideEffect,
+    context: Context,
     navigateToNextScreen: () -> Unit
 ) {
     when (sideEffect) {
@@ -508,7 +514,10 @@ private fun handleSideEffect(
         }
 
         is SignUpStudentSideEffect.SignUpFailure -> {
-            // TODO: Handle sign up failure
+            val message = sideEffect.message.ifBlank {
+                context.getString(R.string.sign_up_user_info_sign_up_failed)
+            }
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         }
     }
 }

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/student/SignUpStudentViewModel.kt
@@ -230,7 +230,7 @@ class SignUpStudentViewModel @Inject constructor(
         ).onSuccess {
             postSideEffect(SignUpStudentSideEffect.SignUpSuccess)
         }.onFailure {
-            postSideEffect(SignUpStudentSideEffect.SignUpFailure)
+            postSideEffect(SignUpStudentSideEffect.SignUpFailure(it.message ?: ""))
         }
     }
 }

--- a/feature/user/src/main/res/values/strings.xml
+++ b/feature/user/src/main/res/values/strings.xml
@@ -150,6 +150,7 @@
     <string name="sign_up_user_info_department_hint">학부를 선택해주세요.</string>
     <string name="sign_up_user_info_student_number_hint">학번을 입력해주세요.</string>
     <string name="sign_up_user_info_student_number_wrong_format">올바른 학번 양식이 아닙니다. 다시 입력해 주세요.</string>
+    <string name="sign_up_user_info_sign_up_failed">회원가입에 실패했습니다.</string>
 
     <string name="sign_up_next">다음</string>
 


### PR DESCRIPTION
## PR 개요
이슈 번호: #45

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
회원가입 실패 시 사용자에게 에러 피드백이 제공되지 않는 문제를 해결합니다.

**주요 변경사항:**
1.  **Repository 에러 처리 강화:** `SignupRepositoryImpl.kt`에서 `HttpException` 발생 시 `runCatching`을 사용하여 서버에서 반환된 에러 메시지를 안전하게 추출하고, 네트워크 오류 등 일반 `Throwable` 예외도 처리하도록 개선했습니다. `CancellationException`은 반드시 재던지도록 하여 코루틴 취소를 보장합니다.
2.  **SideEffect 메시지 매개변수화:** `SignUpGeneralSideEffect.SignUpFailure` 및 `SignUpStudentSideEffect.SignUpFailure`를 `data object`에서 에러 메시지를 포함하는 `data class`로 변경했습니다.
3.  **ViewModel에서 에러 메시지 전달:** 회원가입 API 호출 실패 시, ViewModel에서 추출된 에러 메시지를 `SignUpFailure` side effect와 함께 전달하도록 수정했습니다.
4.  **UI에서 Toast 메시지 표시:** `SignUpGeneralUserInfo.kt`와 `SignUpStudentUserInfo.kt`에서 `LocalContext`를 사용하여 Toast 메시지를 표시하도록 구현했습니다. 서버에서 받은 에러 메시지가 비어있을 경우, 기본 문자열 리소스("회원가입에 실패했습니다.")를 사용합니다.
5.  **문자열 리소스 추가:** 에러 메시지에 사용될 `sign_up_user_info_sign_up_failed` 문자열 리소스를 `strings.xml`에 추가했습니다.

### 논의 사항
(없음)

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다