### PR TITLE
[Fix] UserRepositoryImpl updateUserPassword 에러 핸들링 추가

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
@@ -25,6 +25,7 @@ import `in`.koreatech.koin.domain.model.user.User
 import `in`.koreatech.koin.domain.model.user.UserType
 import `in`.koreatech.koin.domain.repository.UserRepository
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -205,8 +206,12 @@ class UserRepositoryImpl @Inject constructor(
         hashedPassword: String
     ): Result<Unit> {
         return runCatching {
-            userRemoteDataSource.updateUserPassword(hashedPassword) // TODO: Handle error after error code PR is completed.
-        }
+            userRemoteDataSource.updateUserPassword(hashedPassword)
+        }.onFailure { if (it is CancellationException) throw it }
+            .mapHttpFailure {
+                on(400) throws KoinUserException.DataInvalidException()
+                on(401) throws KoinUserException.UnauthorizedException()
+            }
     }
 
     override suspend fun requestSmsVerification(phoneNumber: String): Result<CodeCount> {


### PR DESCRIPTION
## PR 개요
이슈 번호: #48

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
`UserRepositoryImpl.updateUserPassword()` 메서드의 에러 핸들링 완성. `runCatching` 블록 이후 `.onFailure { if (it is CancellationException) throw it }` 추가로 코루틴 취소 예외 명시적 전파. `.mapHttpFailure { ... }` DSL 오버로드 적용 (`NetworkUtil.kt:66-75`) - `on(400) throws KoinUserException.DataInvalidException()`, `on(401) throws KoinUserException.UnauthorizedException()`. 기존 TODO 주석 제거. 동일 파일의 다른 API 메서드들(`requestSmsVerification`, `requestEmailVerification` 등)과 일관된 패턴 유지.

### 논의 사항
- PLAN.md에서 언급한 "PUT users/password API의 실제 에러 응답 스펙 검증" 은 완료 조건에 포함되지 않았으나, 구현된 매핑(400/401 상태 코드)은 표준 REST API 관례에 부합하고 에러 코드 단위 분기가 불필요한 경우로 판단됨.
- 비밀번호 변경 실패 시 UI 레이어의 에러 피드백 개선(토스트/경고 메시지)은 별도 이슈(`ChangePasswordScreen` Compose 개선)로 분리 필요.

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다