### PR TITLE
[Fix] 시간표 에러 토스트에 하드코딩된 임시 메시지가 표시되는 문제 수정

### DIFF
--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/viewmodel/TimetableViewModel.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/viewmodel/TimetableViewModel.kt
@@ -33,6 +33,7 @@ import `in`.koreatech.koin.feature.timetable.utils.toTimetableEvents
 import `in`.koreatech.koin.feature.timetable.view.TimetableBottomSheetContentMode
 import javax.inject.Inject
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -69,7 +70,7 @@ class TimetableViewModel @Inject constructor(
     val searchEngineState: StateFlow<SearchEngineState> = _searchEngineState.asStateFlow()
 
     private val _lectures = MutableStateFlow<List<Lecture>>(emptyList())
-    val lectures =
+    val lectures: StateFlow<List<Lecture>> =
         combine(_searchEngineState, _lectures) { searchEngineState, lectures ->
             if (searchEngineState.text.isBlank() && searchEngineState.department.isBlank()) {
                 lectures
@@ -121,8 +122,9 @@ class TimetableViewModel @Inject constructor(
                                     loading = false
                                 )
                         }.onFailure {
+                            if (it is CancellationException) throw it
                             updateLoading(false)
-                            _sideEffect.value = TimetableSideEffect.Toast("Failed get timetable lectures : " + it.message.orEmpty())
+                            _sideEffect.value = TimetableSideEffect.Toast("시간표 강의를 불러오지 못했습니다.")
                         }
                 }
 
@@ -152,8 +154,9 @@ class TimetableViewModel @Inject constructor(
                                     loading = false
                                 )
                         }.onFailure {
+                            if (it is CancellationException) throw it
                             updateLoading(false)
-                            _sideEffect.value = TimetableSideEffect.Toast("Failed get timetable lectures : " + it.message.orEmpty())
+                            _sideEffect.value = TimetableSideEffect.Toast("시간표 강의를 불러오지 못했습니다.")
                         }
                 }
             }
@@ -198,8 +201,9 @@ class TimetableViewModel @Inject constructor(
                                     loading = false
                                 )
                         }.onFailure {
+                            if (it is CancellationException) throw it
                             updateLoading(false)
-                            _sideEffect.value = TimetableSideEffect.Toast("Failed get timetable lectures : " + it.message.orEmpty())
+                            _sideEffect.value = TimetableSideEffect.Toast("시간표 강의를 불러오지 못했습니다.")
                         }
                 }
                 false -> {
@@ -248,8 +252,9 @@ class TimetableViewModel @Inject constructor(
                                     loading = false
                                 )
                         }.onFailure {
+                            if (it is CancellationException) throw it
                             updateLoading(false)
-                            _sideEffect.value = TimetableSideEffect.Toast("Failed get timetable lectures : " + it.message.orEmpty())
+                            _sideEffect.value = TimetableSideEffect.Toast("시간표 강의를 불러오지 못했습니다.")
                         }
                 }
             }
@@ -258,19 +263,22 @@ class TimetableViewModel @Inject constructor(
 
     private suspend fun getSemester(isAnonymous: Boolean): List<String> {
         return getSemesterUseCase(isAnonymous).catch {
-            _sideEffect.value = TimetableSideEffect.Toast("Failed get semester : " + it.message.orEmpty())
+            if (it is CancellationException) throw it
+            _sideEffect.value = TimetableSideEffect.Toast("학기 정보를 불러오지 못했습니다.")
         }.firstOrNull().orEmpty()
     }
 
     private suspend fun getLectures(semester: String): List<Lecture> {
         return getLecturesUseCase(semester).catch {
+            if (it is CancellationException) throw it
             _lectures.value = emptyList()
         }.firstOrNull().orEmpty()
     }
 
     private suspend fun getTimetableFrames(semester: String): List<TimetableFrame> {
         return getTimetableFramesUseCase(semester).catch {
-            _sideEffect.value = TimetableSideEffect.Toast("Failed get timetable frame : " + it.message.orEmpty())
+            if (it is CancellationException) throw it
+            _sideEffect.value = TimetableSideEffect.Toast("시간표 정보를 불러오지 못했습니다.")
         }.firstOrNull().orEmpty()
     }
 
@@ -617,8 +625,9 @@ class TimetableViewModel @Inject constructor(
                 _customContentState.value = CustomContentState()
                 updateIsLectureDuplicationDialogVisible(false)
             }.onFailure {
+                if (it is CancellationException) throw it
                 updateLoading(false)
-                _sideEffect.value = TimetableSideEffect.Toast("Failed add timetable lectures : " + it.message.orEmpty())
+                _sideEffect.value = TimetableSideEffect.Toast("강의 추가에 실패했습니다.")
             }
         }
     }
@@ -666,11 +675,13 @@ class TimetableViewModel @Inject constructor(
                             addTimetableLectures(lecture)
                         } ?: return@onSuccess
                     }.onFailure {
+                        if (it is CancellationException) throw it
+                        updateLoading(false)
                         _dialogState.value =
                             _dialogState.value.copy(
                                 isLectureDuplicationVisible = false
                             )
-                        _sideEffect.value = TimetableSideEffect.Toast("Failed delete timetable lectures : " + it.message.orEmpty())
+                        _sideEffect.value = TimetableSideEffect.Toast("강의 삭제에 실패했습니다.")
                     }
                 }
             }
@@ -746,8 +757,9 @@ class TimetableViewModel @Inject constructor(
                             )
                         updateIsLectureDuplicationDialogVisible(false)
                     }.onFailure {
+                        if (it is CancellationException) throw it
                         updateLoading(false)
-                        _sideEffect.value = TimetableSideEffect.Toast("Failed add timetable lectures : " + it.message.orEmpty())
+                        _sideEffect.value = TimetableSideEffect.Toast("강의 추가에 실패했습니다.")
                     }
                 }
             }
@@ -811,12 +823,14 @@ class TimetableViewModel @Inject constructor(
                                         loading = false
                                     )
                             }.onFailure {
+                                if (it is CancellationException) throw it
                                 updateLoading(false)
-                                _sideEffect.value = TimetableSideEffect.Toast("Failed get timetable lectures : " + it.message.orEmpty())
+                                _sideEffect.value = TimetableSideEffect.Toast("시간표 강의를 불러오지 못했습니다.")
                             }
                     }.onFailure {
+                        if (it is CancellationException) throw it
                         updateLoading(false)
-                        _sideEffect.value = TimetableSideEffect.Toast("Failed delete timetable lectures : " + it.message.orEmpty())
+                        _sideEffect.value = TimetableSideEffect.Toast("강의 삭제에 실패했습니다.")
                     }
                 }
             }
@@ -825,61 +839,72 @@ class TimetableViewModel @Inject constructor(
 
     fun removeTimetableLectureById(id: Int) {
         if (state.value.isAnonymous) {
-            val updatedTimetableLectures = _state.value.timetableLectures.timetable.toMutableList()
-            updatedTimetableLectures.removeIf { it.id == id }
-            val timetables =
-                _state.value.timetableLectures.copy(
-                    timetable = updatedTimetableLectures
-                )
+            removeTimetableLectureByIdAnonymous(id)
+        } else {
+            removeTimetableLectureByIdNonAnonymous(id)
+        }
+    }
 
-            viewModelScope.launch {
-                updateLoading(true)
-                timetableRepository.putTimetableLectures(state.value.currentSemester, timetables)
+    private fun removeTimetableLectureByIdAnonymous(id: Int) {
+        val updatedTimetableLectures = _state.value.timetableLectures.timetable.toMutableList()
+        updatedTimetableLectures.removeIf { it.id == id }
+        val timetables =
+            _state.value.timetableLectures.copy(
+                timetable = updatedTimetableLectures
+            )
+
+        viewModelScope.launch {
+            updateLoading(true)
+            timetableRepository.putTimetableLectures(state.value.currentSemester, timetables)
+                .onSuccess { timetableLectures ->
+                    _state.value =
+                        _state.value.copy(
+                            range = timetableLectures.formatTimeRange(),
+                            timetableLectures = timetableLectures,
+                            timetableEvents = timetableLectures.getTimetableEvents(),
+                            clickedTimetableEvents = emptyList(),
+                            etcClickedTimetableEvents = emptyList(),
+                            bottomSheetCollapse = true,
+                            selectedLecture = null,
+                            loading = false
+                        )
+                    updateIsLectureDuplicationDialogVisible(false)
+                }.onFailure {
+                    if (it is CancellationException) throw it
+                    updateLoading(false)
+                    updateIsLectureDuplicationDialogVisible(false)
+                    _sideEffect.value = TimetableSideEffect.Toast("강의 수정에 실패했습니다.")
+                }
+        }
+    }
+
+    private fun removeTimetableLectureByIdNonAnonymous(id: Int) {
+        viewModelScope.launch {
+            updateLoading(true)
+            deleteTimetableLectureUseCase(id).onSuccess {
+                timetableRepository.getTimetableLectures(state.value.frameId)
                     .onSuccess { timetableLectures ->
                         _state.value =
                             _state.value.copy(
                                 range = timetableLectures.formatTimeRange(),
-                                timetableLectures = timetableLectures,
+                                frameId = timetableLectures.timetableFrameId,
                                 timetableEvents = timetableLectures.getTimetableEvents(),
                                 clickedTimetableEvents = emptyList(),
                                 etcClickedTimetableEvents = emptyList(),
                                 bottomSheetCollapse = true,
                                 selectedLecture = null,
+                                timetableLectures = timetableLectures,
                                 loading = false
                             )
-                        updateIsLectureDuplicationDialogVisible(false)
                     }.onFailure {
+                        if (it is CancellationException) throw it
                         updateLoading(false)
-                        updateIsLectureDuplicationDialogVisible(false)
-                        _sideEffect.value = TimetableSideEffect.Toast("Failed put timetable lectures : " + it.message.orEmpty())
+                        _sideEffect.value = TimetableSideEffect.Toast("시간표 강의를 불러오지 못했습니다.")
                     }
-            }
-        } else {
-            viewModelScope.launch {
-                updateLoading(true)
-                deleteTimetableLectureUseCase(id).onSuccess {
-                    timetableRepository.getTimetableLectures(state.value.frameId)
-                        .onSuccess { timetableLectures ->
-                            _state.value =
-                                _state.value.copy(
-                                    range = timetableLectures.formatTimeRange(),
-                                    frameId = timetableLectures.timetableFrameId,
-                                    timetableEvents = timetableLectures.getTimetableEvents(),
-                                    clickedTimetableEvents = emptyList(),
-                                    etcClickedTimetableEvents = emptyList(),
-                                    bottomSheetCollapse = true,
-                                    selectedLecture = null,
-                                    timetableLectures = timetableLectures,
-                                    loading = false
-                                )
-                        }.onFailure {
-                            updateLoading(false)
-                            _sideEffect.value = TimetableSideEffect.Toast("Failed get timetable lectures : " + it.message.orEmpty())
-                        }
-                }.onFailure {
-                    updateLoading(false)
-                    _sideEffect.value = TimetableSideEffect.Toast("Failed delete timetable lectures by id : " + it.message.orEmpty())
-                }
+            }.onFailure {
+                if (it is CancellationException) throw it
+                updateLoading(false)
+                _sideEffect.value = TimetableSideEffect.Toast("강의 삭제에 실패했습니다.")
             }
         }
     }
@@ -901,9 +926,10 @@ class TimetableViewModel @Inject constructor(
                         )
                     updateIsLectureDuplicationDialogVisible(false)
                 }.onFailure {
+                    if (it is CancellationException) throw it
                     updateLoading(false)
                     updateIsLectureDuplicationDialogVisible(false)
-                    _sideEffect.value = TimetableSideEffect.Toast("Failed put timetable lectures : " + it.message.orEmpty())
+                    _sideEffect.value = TimetableSideEffect.Toast("강의 수정에 실패했습니다.")
                 }
         }
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableActivity.kt
@@ -359,13 +359,13 @@ class TimetableActivity : KoinNavigationDrawerActivity() {
                     }
 
                     is TimetableSideEffect.Toast -> {
-                        // TODO::현재는 에러 메세지를 띄우는 용로도 토스트가 사용되기에 임시 메세지 사용, 배포 후 수정 필요
                         Timber.d("TimetableSideEffect.Toast| ${effect.message}")
                         Toast.makeText(
                             this@TimetableActivity,
-                            "인터넷 연결을 확인하고 다시 시도해주세요.",
+                            effect.message,
                             Toast.LENGTH_SHORT
                         ).show()
+                        viewModel.updateSideEffect(TimetableSideEffect.Nothing)
                     }
 
                     is TimetableSideEffect.Nothing -> Unit


### PR DESCRIPTION
## PR 개요
이슈 번호: #44

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `TimetableViewModel.kt`: 15개 지점에서 영어 개발자용 에러 메시지를 한국어 고정 문자열로 교체했습니다.
- `TimetableActivity.kt`: 토스트 핸들러에서 `effect.message`를 직접 사용하도록 변경하고, `SnackBar`와 동일하게 `viewModel.updateSideEffect(TimetableSideEffect.Nothing)`을 호출하여 상태를 소비 후 초기화하도록 수정했습니다.

### 논의 사항
- `strings.xml` 리소스 사용 대신, 기존 `SnackBar` 패턴과 동일하게 인라인 한국어 문자열을 사용했습니다. 향후 `Toast`/`SnackBar` 모두 `@StringRes` 방식으로 통일하는 리팩토링이 필요합니다.
- `StateFlow` 기반에서 동일 메시지 토스트가 연속으로 발행될 때 표시되지 않는 문제를 `viewModel.updateSideEffect(TimetableSideEffect.Nothing)` 호출로 해결했습니다.
- 장기적으로 `Toast`/`SnackBar` 이벤트를 `SharedFlow` 또는 `Channel` 기반 one-shot event로 교체하는 것을 고려할 수 있습니다.

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다