### PR TITLE
[Feature] 시간표 프레임 편집 다이얼로그 UI 완성

### DIFF
--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/view/dialog/EditTimetableFrameDialog.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/view/dialog/EditTimetableFrameDialog.kt
@@ -1,18 +1,17 @@
 package `in`.koreatech.koin.feature.timetable.view.dialog
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
@@ -23,12 +22,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
@@ -51,9 +52,9 @@ fun EditTimetableFrameDialog(
     onDeleteFrame: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var isMain by remember { mutableStateOf(timetableFrameState?.isMain ?: false) }
-    var timetableName by remember { mutableStateOf(timetableFrameState?.timetableName ?: "") }
-    var showingDeleteDialog by remember { mutableStateOf(false) }
+    var isMain by rememberSaveable(timetableFrameState?.id) { mutableStateOf(timetableFrameState?.isMain ?: false) }
+    var timetableName by rememberSaveable(timetableFrameState?.id) { mutableStateOf(timetableFrameState?.timetableName ?: "") }
+    var showingDeleteDialog by rememberSaveable(timetableFrameState?.id) { mutableStateOf(false) }
 
     // TODO:: 최대 길이에 관련된 명세 추가되면 수정
     val maxTimetableFrameNameLength = remember { 200 }
@@ -76,10 +77,8 @@ fun EditTimetableFrameDialog(
         },
         onClickDelete = { showingDeleteDialog = true },
         onValueChanged = {
-            // 텍스트를 지우거나 최대 길이보다 짧다면 갱신
-            if (it.length < maxTimetableFrameNameLength ||
-                it.length < timetableName.length
-            ) {
+            // 최대 길이 제한
+            if (it.length <= maxTimetableFrameNameLength) {
                 timetableName = it
             }
         },
@@ -119,37 +118,51 @@ private fun EditTimetableFrameDialog(
         modifier = modifier,
         onDismissRequest = onDismiss
     ) {
-        Box(
-            modifier =
-            Modifier
-                .wrapContentWidth()
-                .wrapContentHeight()
-                .background(color = KoinTheme.colors.neutral0, shape = KoinTheme.shapes.extraSmall)
-                .padding(horizontal = 24.dp)
+        Surface(
+            modifier = Modifier
+                .clickable(
+                    onClick = {},
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                    role = null,
+                    onClickLabel = null
+                )
+                .semantics { },
+            shape = KoinTheme.shapes.extraSmall,
+            color = KoinTheme.colors.neutral0
         ) {
-            FilledTextButton(
-                modifier =
-                Modifier
-                    .padding(top = 16.dp)
-                    .height(24.dp),
-                text = stringResource(id = R.string.edit_titletable_frame_delete),
-                textStyle = KoinTheme.typography.medium14,
-                buttonStyle = FilledButtonType.Danger,
-                onClick = onClickDelete
-            )
             Column(
                 modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(vertical = 26.dp, horizontal = 0.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(10.dp)
+                    .padding(horizontal = 24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
+                Row(
+                    modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    FilledTextButton(
+                        modifier =
+                        Modifier
+                            .heightIn(min = 48.dp),
+                        text = stringResource(id = R.string.edit_titletable_frame_delete),
+                        textStyle = KoinTheme.typography.medium14,
+                        buttonStyle = FilledButtonType.Danger,
+                        onClick = onClickDelete
+                    )
+                }
+                Spacer(modifier = Modifier.height(16.dp))
                 Text(
                     text = stringResource(id = R.string.edit_titletable_frame_title),
                     style = KoinTheme.typography.bold16
                 )
+                Spacer(modifier = Modifier.height(10.dp))
                 // TODO:: 높이 수정 필요
+                val textFieldShape = KoinTheme.shapes.extraSmall
                 TextField(
                     modifier =
                     Modifier
@@ -160,40 +173,42 @@ private fun EditTimetableFrameDialog(
                                 width = 1.dp,
                                 color = KoinTheme.colors.neutral300
                             ),
-                            shape = KoinTheme.shapes.extraSmall
+                            shape = textFieldShape
                         ),
+                    shape = textFieldShape,
                     value = timetableName,
-                    textStyle =
-                    KoinTheme.typography.regular14.copy(
-                        color = KoinTheme.colors.neutral500
-                    ),
+                    textStyle = KoinTheme.typography.regular14,
                     colors =
                     TextFieldDefaults.colors(
                         unfocusedContainerColor = KoinTheme.colors.neutral100, // 배경색 (클릭 X)
                         focusedContainerColor = KoinTheme.colors.neutral100, // 배경색 (클릭 O)
                         unfocusedIndicatorColor = Color.Transparent, // 밑줄색 (클릭 X)
                         focusedIndicatorColor = Color.Transparent, // 밑줄색 (클릭 O)
-                        cursorColor = Color.Black, // 클릭 시, 커서색
-                        focusedTextColor = Color.Black // 클릭 시, 입력 텍스트 색
+                        unfocusedTextColor = KoinTheme.colors.neutral500, // 클릭 X 시 텍스트 색
+                        focusedTextColor = KoinTheme.colors.neutral500, // 클릭 O 시 텍스트 색
+                        cursorColor = KoinTheme.colors.primary500 // 클릭 시, 커서색
                     ),
                     singleLine = true,
                     onValueChange = onValueChanged
                 )
+                Spacer(modifier = Modifier.height(10.dp))
                 TextCheckbox(
+                    modifier = Modifier.align(Alignment.Start),
                     text = stringResource(id = R.string.edit_titletable_frame_main),
                     textStyle = KoinTheme.typography.medium14,
                     isChecked = isMain,
                     enabled = isCheckboxEnabled,
                     onCheckChanged = onCheckChanged
                 )
+                Spacer(modifier = Modifier.height(10.dp))
                 Row(
-                    modifier = Modifier.wrapContentHeight(),
+                    modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     OutlinedBoxButton(
                         modifier =
                         Modifier
-                            .height(48.dp)
+                            .heightIn(min = 48.dp)
                             .weight(1.0F),
                         text = stringResource(id = R.string.common_cancellation),
                         onClick = onDismiss,
@@ -202,12 +217,13 @@ private fun EditTimetableFrameDialog(
                     FilledTextButton(
                         modifier =
                         Modifier
-                            .height(48.dp)
+                            .heightIn(min = 48.dp)
                             .weight(1.0F),
                         text = stringResource(id = R.string.common_save),
                         onClick = onConfirm
                     )
                 }
+                Spacer(modifier = Modifier.height(16.dp))
             }
         }
     }
@@ -221,22 +237,29 @@ private fun DeleteTimetableFrameDialog(
     onConfirm: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val title =
-        stringArrayResource(id = R.array.delete_titletable_frame_title).apply {
-            this[0] = String.format(this[0], timetableName)
-        }
+    val baseTitle = stringArrayResource(id = R.array.delete_titletable_frame_title)
+    val title = remember(timetableName, baseTitle.contentHashCode()) {
+        baseTitle.mapIndexed { index, text ->
+            if (index == 0) text.format(timetableName) else text
+        }.toTypedArray()
+    }
 
     BasicAlertDialog(
         onDismissRequest = onDismiss,
         modifier = modifier
     ) {
         Surface(
-            modifier =
-            Modifier
-                .wrapContentWidth()
-                .wrapContentHeight(),
+            modifier = Modifier
+                .clickable(
+                    onClick = {},
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                    role = null,
+                    onClickLabel = null
+                )
+                .semantics { },
             shape = KoinTheme.shapes.extraSmall,
-            color = Color.White
+            color = KoinTheme.colors.neutral0
         ) {
             Column(
                 modifier =
@@ -262,13 +285,13 @@ private fun DeleteTimetableFrameDialog(
                 )
                 Spacer(modifier = Modifier.height(24.dp))
                 Row(
-                    modifier = Modifier.wrapContentHeight(),
+                    modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     OutlinedBoxButton(
                         modifier =
                         Modifier
-                            .height(48.dp)
+                            .heightIn(min = 48.dp)
                             .weight(1.0F),
                         text = stringResource(id = R.string.common_cancellation),
                         onClick = onDismiss,
@@ -277,7 +300,7 @@ private fun DeleteTimetableFrameDialog(
                     FilledButton(
                         modifier =
                         Modifier
-                            .height(48.dp)
+                            .heightIn(min = 48.dp)
                             .weight(1.0F),
                         text = stringResource(id = R.string.delete_titletable_frame_confirmation),
                         onClick = onConfirm,


### PR DESCRIPTION
## PR 개요
이슈 번호: #47

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `feature/timetable` 모듈의 `EditTimetableFrameDialog.kt`에서 `onValueChanged` 콜백 경계 조건 버그를 수정했습니다 (`<` → `<=`).
- Code Review 피드백을 반영하여 Compose 접근성 개선 (Surface clickable), TextField Shape 코드 중복 제거, Kotlin 상태 최적화 (remember 키)를 적용했습니다.
- Phase 2 작업 (TextField 높이, `maxTimetableFrameNameLength` 값 갱신)은 외부 스펙 확정 대기 상태로 보류되었으며, 관련 TODO 주석은 유지됩니다.

### 논의 사항
- Phase 2 작업은 백엔드 OpenAPI 명세 및 Figma 디자인 스펙 확정 후 진행될 예정입니다.
- TextField 높이 지정 시 `Modifier.defaultMinSize` 또는 `Modifier.heightIn` 사용 규칙 준수가 권장됩니다.

### 스크린샷
Phase 2 UI 완성은 보류 중이며, Phase 1 버그 수정 및 코드 품질 개선 작업이 적용되었습니다.

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다