### PR TITLE
[Refactor] feature/dining Compose Preview 더미 날짜 리터럴 상수화

### DIFF
--- a/feature/dining/src/main/java/in/koreatech/koin/feature/dining/component/DiningItem.kt
+++ b/feature/dining/src/main/java/in/koreatech/koin/feature/dining/component/DiningItem.kt
@@ -49,6 +49,8 @@ private val IMAGE_SUPPORTED_PLACES = setOf(
     DiningPlace.CornerC.place
 )
 
+private const val PREVIEW_DUMMY_DATE = "2025.05.17"
+
 @Composable
 fun DiningItem(
     dining: Dining,
@@ -285,7 +287,7 @@ private fun DiningItemPreview() {
     DiningItem(
         Dining(
             id = 0,
-            date = "2025.05.17",
+            date = PREVIEW_DUMMY_DATE,
             type = "BREAKFAST",
             place = "A코너",
             priceCard = "1000",
@@ -293,10 +295,10 @@ private fun DiningItemPreview() {
             kcal = "786",
             menu = listOf("밥", "국", "김치"),
             imageUrl = "",
-            createdAt = "2025.05.17",
-            updatedAt = "2025.05.17",
+            createdAt = PREVIEW_DUMMY_DATE,
+            updatedAt = PREVIEW_DUMMY_DATE,
             soldOutAt = "",
-            changedAt = "2025.05.17"
+            changedAt = PREVIEW_DUMMY_DATE
         )
     )
 }
@@ -307,7 +309,7 @@ private fun DiningItemSoldoutPreview() {
     DiningItem(
         Dining(
             id = 0,
-            date = "2025.05.17",
+            date = PREVIEW_DUMMY_DATE,
             type = "아침",
             place = "A코너",
             priceCard = "1000",
@@ -315,10 +317,10 @@ private fun DiningItemSoldoutPreview() {
             kcal = "786",
             menu = listOf("밥", "국", "김치"),
             imageUrl = "",
-            createdAt = "2025.05.17",
-            updatedAt = "2025.05.17",
-            soldOutAt = "2025.05.17",
-            changedAt = "2025.05.17"
+            createdAt = PREVIEW_DUMMY_DATE,
+            updatedAt = PREVIEW_DUMMY_DATE,
+            soldOutAt = PREVIEW_DUMMY_DATE,
+            changedAt = PREVIEW_DUMMY_DATE
         )
     )
 }

--- a/feature/dining/src/main/java/in/koreatech/koin/feature/dining/component/DiningItemOriginal.kt
+++ b/feature/dining/src/main/java/in/koreatech/koin/feature/dining/component/DiningItemOriginal.kt
@@ -40,6 +40,8 @@ import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.domain.model.dining.Dining
 import `in`.koreatech.koin.feature.dining.R
 
+private const val PREVIEW_DUMMY_DATE = "2025.05.17"
+
 @Composable
 fun DiningItemOriginal(
     dining: Dining,
@@ -262,7 +264,7 @@ private fun DiningItemOriginalPreview() {
     DiningItemOriginal(
         Dining(
             id = 0,
-            date = "2025.05.17",
+            date = PREVIEW_DUMMY_DATE,
             type = "BREAKFAST",
             place = "A코너",
             priceCard = "1000",
@@ -270,10 +272,10 @@ private fun DiningItemOriginalPreview() {
             kcal = "786",
             menu = listOf("밥", "국", "김치"),
             imageUrl = "",
-            createdAt = "2025.05.17",
-            updatedAt = "2025.05.17",
+            createdAt = PREVIEW_DUMMY_DATE,
+            updatedAt = PREVIEW_DUMMY_DATE,
             soldOutAt = "",
-            changedAt = "2025.05.17"
+            changedAt = PREVIEW_DUMMY_DATE
         ),
         context = LocalContext.current
     )
@@ -285,7 +287,7 @@ private fun DiningItemOriginalSoldoutPreview() {
     DiningItemOriginal(
         Dining(
             id = 0,
-            date = "2025.05.17",
+            date = PREVIEW_DUMMY_DATE,
             type = "아침",
             place = "A코너",
             priceCard = "1000",
@@ -293,10 +295,10 @@ private fun DiningItemOriginalSoldoutPreview() {
             kcal = "786",
             menu = listOf("밥", "국", "김치"),
             imageUrl = "",
-            createdAt = "2025.05.17",
-            updatedAt = "2025.05.17",
-            soldOutAt = "2025.05.17",
-            changedAt = "2025.05.17"
+            createdAt = PREVIEW_DUMMY_DATE,
+            updatedAt = PREVIEW_DUMMY_DATE,
+            soldOutAt = PREVIEW_DUMMY_DATE,
+            changedAt = PREVIEW_DUMMY_DATE
         ),
         context = LocalContext.current
     )

--- a/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningDetailScreen.kt
+++ b/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningDetailScreen.kt
@@ -644,6 +644,8 @@ private fun DiningDetailScreenImpl(
     }
 }
 
+private const val PREVIEW_DUMMY_DATE = "2025.05.17"
+
 @Composable
 private fun DiningItemByABTest(
     experimentGroup: String,
@@ -720,7 +722,7 @@ private fun DiningScreenPreview() {
         diningList = listOf(
             Dining(
                 id = 0,
-                date = "2025.05.17",
+                date = PREVIEW_DUMMY_DATE,
                 type = "BREAKFAST",
                 place = "A코너",
                 priceCard = "1000",
@@ -728,14 +730,14 @@ private fun DiningScreenPreview() {
                 kcal = "786",
                 menu = listOf("밥", "국", "김치", "아침"),
                 imageUrl = "https://image.utoimage.com/preview/cp872722/2022/12/202212008462_500.jpg",
-                createdAt = "2025.05.17",
-                updatedAt = "2025.05.17",
+                createdAt = PREVIEW_DUMMY_DATE,
+                updatedAt = PREVIEW_DUMMY_DATE,
                 soldOutAt = "",
-                changedAt = "2025.05.17"
+                changedAt = PREVIEW_DUMMY_DATE
             ),
             Dining(
                 id = 0,
-                date = "2025.05.17",
+                date = PREVIEW_DUMMY_DATE,
                 type = "BREAKFAST",
                 place = "B코너",
                 priceCard = "1000",
@@ -743,14 +745,14 @@ private fun DiningScreenPreview() {
                 kcal = "786",
                 menu = listOf("밥", "국", "김치", "아침"),
                 imageUrl = "",
-                createdAt = "2025.05.17",
-                updatedAt = "2025.05.17",
+                createdAt = PREVIEW_DUMMY_DATE,
+                updatedAt = PREVIEW_DUMMY_DATE,
                 soldOutAt = "",
-                changedAt = "2025.05.17"
+                changedAt = PREVIEW_DUMMY_DATE
             ),
             Dining(
                 id = 0,
-                date = "2025.05.17",
+                date = PREVIEW_DUMMY_DATE,
                 type = "아침",
                 place = "LUNCH",
                 priceCard = "1000",
@@ -758,14 +760,14 @@ private fun DiningScreenPreview() {
                 kcal = "786",
                 menu = listOf("밥", "국", "김치", "점심"),
                 imageUrl = "",
-                createdAt = "2025.05.17",
-                updatedAt = "2025.05.17",
+                createdAt = PREVIEW_DUMMY_DATE,
+                updatedAt = PREVIEW_DUMMY_DATE,
                 soldOutAt = "",
-                changedAt = "2025.05.17"
+                changedAt = PREVIEW_DUMMY_DATE
             ),
             Dining(
                 id = 0,
-                date = "2025.05.17",
+                date = PREVIEW_DUMMY_DATE,
                 type = "DINNER",
                 place = "A코너",
                 priceCard = "1000",
@@ -773,10 +775,10 @@ private fun DiningScreenPreview() {
                 kcal = "786",
                 menu = listOf("밥", "국", "김치", "저녁"),
                 imageUrl = "",
-                createdAt = "2025.05.17",
-                updatedAt = "2025.05.17",
+                createdAt = PREVIEW_DUMMY_DATE,
+                updatedAt = PREVIEW_DUMMY_DATE,
                 soldOutAt = "",
-                changedAt = "2025.05.17"
+                changedAt = PREVIEW_DUMMY_DATE
             )
         ),
         sessionId = "",


### PR DESCRIPTION
## PR 개요
이슈 번호: #26

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
feature/dining 모듈의 세 파일(`DiningDetailScreen.kt`, `DiningItem.kt`, `DiningItemOriginal.kt`)에서 Compose Preview 더미 데이터에 직접 하드코딩된 `"2025.05.17"` 날짜 문자열(총 34회)을 각 파일의 `private const val PREVIEW_DUMMY_DATE` 상수로 추출했습니다. 이는 SonarQube `kotlin:S1192` CRITICAL 경고를 해소하기 위함입니다. Production 코드 경로는 변경되지 않았으며, Preview 렌더링 결과도 변경 전과 동일합니다. `soldOutAt = ""` 와 같이 빈 문자열인 필드는 교체 대상에서 제외되었습니다.

### 논의 사항
Preview 렌더링 결과와 SonarQube 경고 해소 여부는 수동 검증이 필요합니다. Production 코드 변경이 없어 기능적 영향은 없습니다.

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다