### PR TITLE
[Fix] runCatching 및 mapHttpFailure 사용 시 CancellationException이 무시되는 문제 수정

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/ArticleRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/ArticleRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.data.repository
 
+import `in`.koreatech.koin.data.mapper.safeApiCall
 import `in`.koreatech.koin.data.request.article.ArticleModifyRequest
 import `in`.koreatech.koin.data.request.article.toRequest
 import `in`.koreatech.koin.data.response.article.ArticleKeywordWrapperResponse
@@ -286,7 +287,7 @@ class ArticleRepositoryImpl @Inject constructor(
     }
 
     override suspend fun fetchArticleLostAndFoundStats(): Result<ArticleLostAndFoundStats> {
-        return runCatching {
+        return safeApiCall {
             articleRemoteDataSource.fetchArticleLostAndFoundStats().toArticleLostAndFoundStats()
         }.mapHttpFailure { }
     }
@@ -294,7 +295,7 @@ class ArticleRepositoryImpl @Inject constructor(
     override suspend fun updateItemFound(
         articleId: Int
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             val response = articleRemoteDataSource.updateItemFound(articleId)
             if (response.isSuccessful) {
                 Unit
@@ -313,7 +314,7 @@ class ArticleRepositoryImpl @Inject constructor(
         newImage: List<String>?,
         deleteImageIds: List<Int>?
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             val response = articleRemoteDataSource.modifyArticleLostAndFound(
                 articleId,
                 ArticleModifyRequest(

--- a/data/src/main/java/in/koreatech/koin/data/repository/BusRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/BusRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.data.repository
 
+import `in`.koreatech.koin.data.mapper.safeApiCall
 import `in`.koreatech.koin.data.source.local.BusLocalDataSource
 import `in`.koreatech.koin.data.source.remote.BusRemoteDataSource
 import `in`.koreatech.koin.domain.model.bus.BusNotice
@@ -19,25 +20,25 @@ class BusRepositoryImpl @Inject constructor(
     private val busLocalDataSource: BusLocalDataSource
 ) : BusRepository {
     override suspend fun fetchBusNotice(): Result<BusNotice> {
-        return runCatching {
+        return safeApiCall {
             busRemoteDataSource.fetchBusNotice().toBusNotice()
         }
     }
 
     override suspend fun fetchShuttleTimetable(id: String): Result<ShuttleTimetable> {
-        return runCatching {
+        return safeApiCall {
             busRemoteDataSource.fetchShuttleTimetable(id).toShuttleTimetable()
         }
     }
 
     override suspend fun fetchShuttleCourses(): Result<ShuttleCourses> {
-        return runCatching {
+        return safeApiCall {
             busRemoteDataSource.fetchShuttleCourses().toShuttleCourses()
         }
     }
 
     override suspend fun fetchExpressTimetable(direction: String): Result<ExpressTimetable> {
-        return runCatching {
+        return safeApiCall {
             busRemoteDataSource.fetchExpressTimetable(direction).toExpressTimetable()
         }
     }
@@ -46,7 +47,7 @@ class BusRepositoryImpl @Inject constructor(
         number: Int,
         direction: String
     ): Result<CityTimetable> {
-        return runCatching {
+        return safeApiCall {
             busRemoteDataSource.fetchCityTimetable(number, direction).toCityTimetable()
         }
     }
@@ -58,7 +59,7 @@ class BusRepositoryImpl @Inject constructor(
         departure: String,
         arrival: String
     ): Result<List<BusSearchResult>> {
-        return runCatching {
+        return safeApiCall {
             busRemoteDataSource.fetchBusSearchResult(
                 date = DateTimeFormatter.ofPattern("yyyy-MM-dd").format(date),
                 time = DateTimeFormatter.ofPattern("HH:mm").format(time),
@@ -70,13 +71,13 @@ class BusRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getLastShownNoticeId(): Result<Int> {
-        return runCatching {
+        return safeApiCall {
             busLocalDataSource.getLastShownNoticeId()
         }
     }
 
     override suspend fun saveLastShownNoticeId(id: Int): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             busLocalDataSource.saveLastShownNoticeId(id)
         }
     }

--- a/data/src/main/java/in/koreatech/koin/data/repository/CallvanRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/CallvanRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.data.repository
 
+import `in`.koreatech.koin.data.mapper.safeApiCall
 import `in`.koreatech.koin.data.mapper.toCallvanChatMessage
 import `in`.koreatech.koin.data.mapper.toCallvanNotification
 import `in`.koreatech.koin.data.mapper.toCallvanPostCreate
@@ -31,7 +32,7 @@ class CallvanRepositoryImpl @Inject constructor(
         departureTime: String,
         maxParticipants: Int
     ): Result<CallvanPostCreate> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.createCallvanPost(
                 CallvanPostCreateRequest(
                     departureType = departureType,
@@ -63,7 +64,7 @@ class CallvanRepositoryImpl @Inject constructor(
         page: Int?,
         limit: Int?
     ): Result<CallvanPostSearch> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.getCallvanPosts(
                 author = author,
                 departures = departures,
@@ -88,7 +89,7 @@ class CallvanRepositoryImpl @Inject constructor(
         isImage: Boolean,
         content: String
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.sendMessage(
                 postId = postId,
                 callvanChatMessageRequest = CallvanChatMessageRequest(
@@ -105,7 +106,7 @@ class CallvanRepositoryImpl @Inject constructor(
     override suspend fun getCallvanChatMessages(
         postId: Int
     ): Result<CallvanChatMessage> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.getCallvanChatMessages(
                 postId = postId
             ).toCallvanChatMessage()
@@ -118,7 +119,7 @@ class CallvanRepositoryImpl @Inject constructor(
     override suspend fun getCallvanPostDetail(
         postId: Int
     ): Result<CallvanPostDetail> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.getCallvanPostDetail(
                 postId = postId
             ).toCallvanPostDetail()
@@ -135,7 +136,7 @@ class CallvanRepositoryImpl @Inject constructor(
         reasons: List<Pair<String, String?>>,
         attachmentUrls: List<String>?
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.reportCallvanUser(
                 postId = postId,
                 callvanUserReportCreateRequest = CallvanUserReportCreateRequest(
@@ -168,7 +169,7 @@ class CallvanRepositoryImpl @Inject constructor(
     override suspend fun closeCallvanPost(
         postId: Int
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.closeCallvanPost(
                 postId = postId
             )
@@ -179,13 +180,13 @@ class CallvanRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getNotifications(): Result<List<CallvanNotification>> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.getNotifications().map { it.toCallvanNotification() }
         }
     }
 
     override suspend fun deleteAllNotifications(): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.deleteAllNotifications()
         }
     }
@@ -193,7 +194,7 @@ class CallvanRepositoryImpl @Inject constructor(
     override suspend fun deleteNotification(
         notificationId: Int
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.deleteNotification(
                 notificationId = notificationId
             )
@@ -203,7 +204,7 @@ class CallvanRepositoryImpl @Inject constructor(
     override suspend fun markNotificationAsRead(
         notificationId: Int
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.markNotificationAsRead(
                 notificationId = notificationId
             )
@@ -211,7 +212,7 @@ class CallvanRepositoryImpl @Inject constructor(
     }
 
     override suspend fun markAllNotificationsAsRead(): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.markAllNotificationsAsRead()
         }
     }
@@ -219,7 +220,7 @@ class CallvanRepositoryImpl @Inject constructor(
     override suspend fun completeCallvanPost(
         postId: Int
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.completeCallvanPost(
                 postId = postId
             )
@@ -232,7 +233,7 @@ class CallvanRepositoryImpl @Inject constructor(
     override suspend fun joinCallvanPost(
         postId: Int
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.joinCallvanPost(
                 postId = postId
             )
@@ -247,7 +248,7 @@ class CallvanRepositoryImpl @Inject constructor(
     override suspend fun leaveCallvanPost(
         postId: Int
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.leaveCallvanPost(
                 postId = postId
             )
@@ -261,7 +262,7 @@ class CallvanRepositoryImpl @Inject constructor(
     override suspend fun reopenCallvanPost(
         postId: Int
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             callvanRemoteDataSource.reopenCallvanPost(
                 postId = postId
             )

--- a/data/src/main/java/in/koreatech/koin/data/repository/ClubRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/ClubRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.data.repository
 
+import `in`.koreatech.koin.data.mapper.safeApiCall
 import `in`.koreatech.koin.data.mapper.toClubCategories
 import `in`.koreatech.koin.data.mapper.toClubDetails
 import `in`.koreatech.koin.data.mapper.toClubEvent
@@ -33,13 +34,13 @@ class ClubRepositoryImpl @Inject constructor(
     private val clubRemoteDataSource: ClubRemoteDataSource
 ) : ClubRepository {
     override suspend fun getClubsCategories(): Result<ClubCategories> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.getClubsCategories().toClubCategories()
         }
     }
 
     override suspend fun getClubHot(): Result<ClubHot> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.getClubHot().toClubHot()
         }
     }
@@ -50,7 +51,7 @@ class ClubRepositoryImpl @Inject constructor(
         isRecruiting: Boolean,
         query: String
     ): Result<Clubs> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.getClubs(categoryId, sortType, isRecruiting, query).toClubs()
         }.mapHttpFailure {
             on(404) throws KoinClubException.ClubCategoryNotFoundException()
@@ -58,7 +59,7 @@ class ClubRepositoryImpl @Inject constructor(
     }
 
     override suspend fun cancelClubLike(clubId: Int): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.cancelClubLike(clubId)
         }.mapHttpFailure {
             on(401) throws KoinClubException.UnauthorizedException()
@@ -67,7 +68,7 @@ class ClubRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getClubDetails(clubId: Int): Result<ClubDetails> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.getClubDetails(clubId).toClubDetails()
         }.mapHttpFailure {
             on(404) throws KoinClubException.ClubNotFoundException()
@@ -88,7 +89,7 @@ class ClubRepositoryImpl @Inject constructor(
         role: String,
         isLikeHidden: Boolean
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.createClub(
                 ClubCreateRequest(
                     name = name,
@@ -123,7 +124,7 @@ class ClubRepositoryImpl @Inject constructor(
         phoneNumber: String,
         isLikeHidden: Boolean
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.modifyClub(
                 clubId = clubId,
                 request = ClubModifyRequest(
@@ -147,13 +148,13 @@ class ClubRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getClubQnas(clubId: Int): Result<ClubQnasInfo> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.getClubQnas(clubId).toClubQnasInfo()
         }
     }
 
     override suspend fun setClubLike(clubId: Int): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.setClubLike(clubId)
         }.mapHttpFailure {
             on(401) throws KoinClubException.UnauthorizedException()
@@ -162,7 +163,7 @@ class ClubRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteClubQna(clubId: Int, qnaId: Int): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             val response = clubRemoteDataSource.deleteClubQna(clubId, qnaId)
             if (response.isSuccessful) {
                 Unit
@@ -176,7 +177,7 @@ class ClubRepositoryImpl @Inject constructor(
     }
 
     override suspend fun setClubEmpowerment(clubId: Int, changedManagerId: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.setClubEmpowerment(ClubEmpowermentRequest(clubId, changedManagerId))
         }.mapHttpFailure {
             on(400) throws KoinClubException.AlreadyLikedException()
@@ -187,7 +188,7 @@ class ClubRepositoryImpl @Inject constructor(
     }
 
     override suspend fun postClubQna(clubId: Int, parentId: Int?, content: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.postClubQna(
                 clubId,
                 ClubQnaRequest(parentId, content)
@@ -202,7 +203,7 @@ class ClubRepositoryImpl @Inject constructor(
     override suspend fun getClubRecruitment(
         clubId: Int
     ): Result<ClubRecruitment> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.getClubRecruitment(clubId).toClubRecruitment()
         }.mapHttpFailure {
             on(400) throws KoinClubException.WrongInputDataException()
@@ -218,7 +219,7 @@ class ClubRepositoryImpl @Inject constructor(
         imageUrl: String,
         content: String?
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.createClubRecruitment(
                 clubId,
                 ClubRecruitmentRequest(
@@ -237,7 +238,7 @@ class ClubRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteClubRecruitment(clubId: Int): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             val response = clubRemoteDataSource.deleteClubRecruitment(clubId)
             if (response.isSuccessful) {
                 Unit
@@ -258,7 +259,7 @@ class ClubRepositoryImpl @Inject constructor(
         imageUrl: String,
         content: String?
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             val response = clubRemoteDataSource.modifyClubRecruitment(
                 clubId,
                 ClubRecruitmentRequest(
@@ -284,7 +285,7 @@ class ClubRepositoryImpl @Inject constructor(
         clubId: Int,
         eventType: String
     ): Result<List<ClubEvent>> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.getClubEvents(clubId, eventType).map { it.toClubEvent() }
         }.mapHttpFailure {
             on(400) throws KoinClubException.WrongInputDataException()
@@ -301,7 +302,7 @@ class ClubRepositoryImpl @Inject constructor(
         introduce: String,
         content: String?
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             val response = clubRemoteDataSource.createClubEvent(
                 clubId,
                 ClubEventRequest(
@@ -328,7 +329,7 @@ class ClubRepositoryImpl @Inject constructor(
         clubId: Int,
         eventId: Int
     ): Result<ClubEvent> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.getClubEvent(clubId, eventId).toClubEvent()
         }.mapHttpFailure {
             on(400) throws KoinClubException.WrongInputDataException()
@@ -337,7 +338,7 @@ class ClubRepositoryImpl @Inject constructor(
     }
 
     override suspend fun searchClubs(query: String): Result<ClubSearch> {
-        return runCatching {
+        return safeApiCall {
             clubRemoteDataSource.searchClubs(query).toClubSearch()
         }.mapHttpFailure {
             on(404) throws KoinClubException.ClubNotFoundException()
@@ -354,7 +355,7 @@ class ClubRepositoryImpl @Inject constructor(
         introduce: String,
         content: String?
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             val response = clubRemoteDataSource.modifyClubEvent(
                 clubId,
                 eventId,
@@ -382,7 +383,7 @@ class ClubRepositoryImpl @Inject constructor(
         clubId: Int,
         eventId: Int
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             val response = clubRemoteDataSource.deleteClubEvent(clubId, eventId)
             if (response.isSuccessful) {
                 Unit
@@ -396,7 +397,7 @@ class ClubRepositoryImpl @Inject constructor(
     }
 
     override suspend fun subscribeClubRecruitment(clubId: Int): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             val response = clubRemoteDataSource.subscribeClubRecruitment(clubId)
             if (response.isSuccessful) {
                 Unit
@@ -411,7 +412,7 @@ class ClubRepositoryImpl @Inject constructor(
     }
 
     override suspend fun unsubscribeClubRecruitment(clubId: Int): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             val response = clubRemoteDataSource.unsubscribeClubRecruitment(clubId)
             if (response.isSuccessful) {
                 Unit
@@ -429,7 +430,7 @@ class ClubRepositoryImpl @Inject constructor(
         clubId: Int,
         eventId: Int
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             val response = clubRemoteDataSource.subscribeClubEvent(clubId, eventId)
             if (response.isSuccessful) {
                 Unit
@@ -447,7 +448,7 @@ class ClubRepositoryImpl @Inject constructor(
         clubId: Int,
         eventId: Int
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             val response = clubRemoteDataSource.unsubscribeClubEvent(clubId, eventId)
             if (response.isSuccessful) {
                 Unit

--- a/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.data.repository
 
+import `in`.koreatech.koin.data.mapper.safeApiCall
 import `in`.koreatech.koin.data.mapper.toBoolean
 import `in`.koreatech.koin.data.mapper.toInt
 import `in`.koreatech.koin.data.mapper.toPhoneNumber
@@ -87,7 +88,7 @@ class SignupRepositoryImpl @Inject constructor(
     }
 
     override suspend fun isUsernameDuplicatedV2(nickname: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.checkNicknameV2(nickname)
         }.mapHttpFailure {
             on(400) throws KoinUserException.NicknameInvalidException()
@@ -96,7 +97,7 @@ class SignupRepositoryImpl @Inject constructor(
     }
 
     override suspend fun isPhoneDuplicated(phone: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.checkPhoneNumberDuplicate(phone)
         }.mapHttpFailure {
             on(400) throws KoinUserException.PhoneNumberInvalidException()
@@ -136,7 +137,7 @@ class SignupRepositoryImpl @Inject constructor(
     }
 
     override suspend fun isLoginIdDuplicated(loginId: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.checkLoginId(loginId)
         }.mapHttpFailure {
             on(400) throws KoinUserException.LoginIdInvalidException()
@@ -145,7 +146,7 @@ class SignupRepositoryImpl @Inject constructor(
     }
 
     override suspend fun isEmailDuplicated(email: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.checkEmail(email)
         }.mapHttpFailure {
             on(400) throws KoinUserException.EmailInvalidException()

--- a/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package `in`.koreatech.koin.data.repository
 
 import `in`.koreatech.koin.data.constant.DBConstant
+import `in`.koreatech.koin.data.mapper.safeApiCall
 import `in`.koreatech.koin.data.mapper.toCart
 import `in`.koreatech.koin.data.mapper.toCartAddRequest
 import `in`.koreatech.koin.data.mapper.toCartItemEdit
@@ -245,7 +246,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getShopSearchRelatedListV2(keyword: String): Result<OrderableShopSearchRelated> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getShopSearchRelatedV2(keyword).toOrderableShopSearchRelated()
         }.mapHttpFailure { }
     }
@@ -256,7 +257,7 @@ class StoreRepositoryImpl @Inject constructor(
         categoryFilter: Int?,
         minimumOrderAmount: Int?
     ): Result<List<Shop>> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getOrderableShops(sorter, filter, categoryFilter, minimumOrderAmount).map { it.toShop() }
         }.mapHttpFailure {
             on(404) throws KoinStoreException.ShopNotFoundException()
@@ -264,7 +265,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getNearbyShops(): Result<List<Shop>> {
-        return runCatching {
+        return safeApiCall {
             storeLocalDataSource.getCachedNearbyShops()?.map { it.toShop() } ?: storeRemoteDataSource.getNearbyShops().shops.also {
                 storeLocalDataSource.setCachedNearbyShops(it)
             }.map {
@@ -276,7 +277,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getOrderableShopSummary(shopId: Int): Result<ShopSummary> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getOrderableShopSummary(shopId).toShopSummary()
         }.mapHttpFailure {
             on(404) throws KoinStoreException.ShopNotFoundException()
@@ -284,7 +285,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getOrderableShopDetail(shopId: Int): Result<ShopDetail> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getOrderableShopDetail(shopId).toShopDetail()
         }.mapHttpFailure {
             on(404) throws KoinStoreException.ShopNotFoundException()
@@ -292,7 +293,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getOrderableShopDelivery(shopId: Int): Result<ShopDeliveryAvailable> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getOrderableShopDelivery(shopId).toShopDeliveryAvailable()
         }.mapHttpFailure {
             on(404) throws KoinStoreException.ShopNotFoundException()
@@ -300,7 +301,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getOrderableShopMenus(shopId: Int): Result<List<ShopMenus>> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getOrderableShopMenus(shopId).map { it.toShopMenus() }
         }.mapHttpFailure {
             on(404) throws KoinStoreException.ShopNotFoundException()
@@ -308,7 +309,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getOrderableShopMenu(shopId: Int, menuId: Int): Result<ShopMenu> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getOrderableShopMenu(shopId, menuId).toShopMenu()
         }.mapHttpFailure {
             on(404) throws KoinStoreException.MenuNotFoundException()
@@ -316,7 +317,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getOrderableShopMenuGroups(shopId: Int): Result<List<ShopMenusGroup>> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getOrderableShopMenuGroups(shopId).map { it.toShopMenusGroup() }
         }.mapHttpFailure {
             on(404) throws KoinStoreException.ShopNotFoundException()
@@ -324,13 +325,13 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getOrderableShopSearchRelated(query: String): Result<OrderableShopSearchRelated> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getOrderableShopSearchRelated(query).toOrderableShopSearchRelated()
         }.mapHttpFailure { }
     }
 
     override suspend fun updateCartItem(cartMenuItemId: Int, cartItem: CartItem): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.updateCartItem(cartMenuItemId, cartItem.toCartItemRequest())
         }.mapHttpFailure {
             on(400, "REQUIRED_OPTION_GROUP_MISSING") throws KoinStoreException.RequiredOptionGroupMissingException()
@@ -345,7 +346,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updateCartItemQuantity(cartMenuItemId: Int, quantity: Int): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.updateCartItemQuantity(cartMenuItemId, quantity)
         }.mapHttpFailure {
             on(400) throws KoinStoreException.InvalidQuantityException()
@@ -356,7 +357,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun addCartItem(cartAdd: CartAdd): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.addCartItem(cartAdd.toCartAddRequest())
         }.mapHttpFailure {
             on(400, "DIFFERENT_SHOP_ITEM_IN_CART") throws KoinStoreException.DifferentShopItemInCartException()
@@ -372,7 +373,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getCartItems(type: String): Result<Cart> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getCartItems(type).toCart()
         }.mapHttpFailure {
             on(400, "SHOP_NOT_DELIVERABLE") throws KoinStoreException.ShopNotDeliverableException()
@@ -382,7 +383,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun validateCartItems(orderType: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.validateCartItems(orderType)
         }.mapHttpFailure {
             on(400, "ORDER_AMOUNT_BELOW_MINIMUM") throws KoinStoreException.OrderAmountBelowMinimumException()
@@ -393,7 +394,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getCartSummary(orderableShopId: Int): Result<CartSummary> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getCartSummary(orderableShopId).toCartSummary()
         }.mapHttpFailure {
             on(401) throws KoinStoreException.UnauthorizedException()
@@ -401,7 +402,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getCartPaymentSummary(type: String): Result<CartPaymentSummary> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getCartPaymentSummary(type).toCartPaymentSummary()
         }.mapHttpFailure {
             on(400, "SHOP_NOT_DELIVERABLE") throws KoinStoreException.ShopNotDeliverableException()
@@ -411,7 +412,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getCartItemEdit(cartMenuItemId: Int): Result<CartItemEdit> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getCartItemEdit(cartMenuItemId).toCartItemEdit()
         }.mapHttpFailure {
             on(401) throws KoinStoreException.UnauthorizedException()
@@ -420,7 +421,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun resetCart(): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.resetCart()
             Unit
         }.mapHttpFailure {
@@ -430,7 +431,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteCartItem(cartMenuItemId: Int): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.deleteCartItem(cartMenuItemId)
             Unit
         }.mapHttpFailure {
@@ -441,7 +442,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getCartItemsCount(): Result<CartItemsCount> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getCartItemsCount().toCartItemsCount()
         }.mapHttpFailure {
             on(401) throws KoinStoreException.UnauthorizedException()
@@ -449,7 +450,7 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getOrderInProgress(): Result<List<OrderInProgress>> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getOrderInProgress().map { it.toOrderInProgress() }
         }.mapHttpFailure { }
     }
@@ -462,7 +463,7 @@ class StoreRepositoryImpl @Inject constructor(
         type: String?,
         query: String?
     ): Result<OrderHistoryRelated> {
-        return runCatching {
+        return safeApiCall {
             storeRemoteDataSource.getOrderHistories(page, limit, period, status, type, query).toOrderHistoryRelated()
         }.mapHttpFailure { }
     }

--- a/data/src/main/java/in/koreatech/koin/data/repository/TimetableRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/TimetableRepositoryImpl.kt
@@ -2,6 +2,7 @@ package `in`.koreatech.koin.data.repository
 
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import `in`.koreatech.koin.data.mapper.safeApiCall
 import `in`.koreatech.koin.data.request.timetable.LectureQueryRequest
 import `in`.koreatech.koin.data.request.timetable.LecturesQueryRequest
 import `in`.koreatech.koin.data.request.timetable.TimetableFrameCreateQueryRequest
@@ -61,12 +62,12 @@ class TimetableRepositoryImpl @Inject constructor(
         }
 
     override suspend fun getTimetableLectures(timetableFrameId: Int): Result<TimetableLectures> =
-        runCatching {
+        safeApiCall {
             timetableRemoteDataSource.getTimetableLectures(timetableFrameId).toTimetableLectures()
         }
 
     override suspend fun getTimetableLectures(semester: String): Result<TimetableLectures> =
-        runCatching {
+        safeApiCall {
             val timetableLecturesString = timetableDataStore.getString(semester).firstOrNull().orEmpty()
             val timetableLecturesType = object : TypeToken<TimetableLectures>() {}.type
             try {
@@ -77,29 +78,29 @@ class TimetableRepositoryImpl @Inject constructor(
         }
 
     override suspend fun putTimetableLectures(lectures: TimetableLecturesQuery): Result<TimetableLectures> =
-        runCatching {
+        safeApiCall {
             timetableRemoteDataSource.putTimetableLectures(lectures.toTimetableLecturesQueryRequest()).toTimetableLectures()
         }
 
     override suspend fun putTimetableLectures(
         key: String,
         value: TimetableLectures
-    ): Result<TimetableLectures> =
-        runCatching {
+    ): Result<TimetableLectures> {
+        return safeApiCall {
             timetableDataStore.putString(key, gson.toJson(value))
-            return getTimetableLectures(semester = key)
-                .onSuccess {
-                    Result.success(it)
-                }.onFailure {
-                    Result.failure<TimetableLectures>(it)
-                }
         }
+            // fold avoids non-local return — safeApiCall lambda is not inline
+            .fold(
+                onSuccess = { getTimetableLectures(semester = key) },
+                onFailure = { Result.failure(it) }
+            )
+    }
 
     override suspend fun putTimetableFrame(
         id: Int,
         frame: TimetableFrameQuery
     ): Result<TimetableFrame> =
-        runCatching {
+        safeApiCall {
             timetableRemoteDataSource
                 .putTimetableFrame(
                     id,
@@ -114,7 +115,7 @@ class TimetableRepositoryImpl @Inject constructor(
         frameId: Int,
         lectures: List<Lecture>
     ): Result<TimetableLectures> =
-        runCatching {
+        safeApiCall {
             timetableRemoteDataSource
                 .postTimetableLectures(
                     LecturesQueryRequest(
@@ -128,7 +129,7 @@ class TimetableRepositoryImpl @Inject constructor(
         frameId: Int,
         lectures: List<Lecture>
     ): Result<TimetableLectures> =
-        runCatching {
+        safeApiCall {
             val info =
                 lectures.map { it.classTime to it.place }.map { (classTime, place) ->
                     TimetableLectureClassInfoRequest(classTime = classTime, classPlace = place)
@@ -157,7 +158,7 @@ class TimetableRepositoryImpl @Inject constructor(
         frameId: Int,
         lectures: List<TimetableLecture>
     ): Result<TimetableLectures> =
-        runCatching {
+        safeApiCall {
             val queryLectures =
                 lectures.map {
                     if (it.lectureId == 0) {
@@ -177,7 +178,7 @@ class TimetableRepositoryImpl @Inject constructor(
         }
 
     override suspend fun postTimetableFrame(frame: TimetableFrameCreateQuery): Result<TimetableFrame> =
-        runCatching {
+        safeApiCall {
             timetableRemoteDataSource
                 .postTimetableFrame(
                     TimetableFrameCreateQueryRequest(
@@ -194,17 +195,17 @@ class TimetableRepositoryImpl @Inject constructor(
         }
 
     override suspend fun postRollbackFrame(frameId: Int): Result<TimetableLectures> =
-        runCatching {
+        safeApiCall {
             timetableRemoteDataSource.postRollbackFrame(frameId).toTimetableLectures()
         }
 
     override suspend fun deleteTimetableFrame(frameId: Int): Result<Unit> =
-        runCatching {
+        safeApiCall {
             timetableRemoteDataSource.deleteTimetableFrame(frameId)
         }
 
     override suspend fun deleteTimetableLecture(id: Int): Result<Unit> =
-        runCatching {
+        safeApiCall {
             timetableRemoteDataSource.deleteTimetableLecture(id)
         }
 
@@ -212,12 +213,12 @@ class TimetableRepositoryImpl @Inject constructor(
         frameId: Int,
         lectureId: Int
     ): Result<Unit> =
-        runCatching {
+        safeApiCall {
             timetableRemoteDataSource.deleteTimetableFrameLecture(frameId, lectureId)
         }
 
     override suspend fun deleteTimetableLectures(lectureIds: List<Int>): Result<Unit> =
-        runCatching {
+        safeApiCall {
             val response = timetableRemoteDataSource.deleteTimetableLectures(lectureIds)
             if (!response.isSuccessful) {
                 throw HttpException(response)
@@ -225,7 +226,7 @@ class TimetableRepositoryImpl @Inject constructor(
         }
 
     override suspend fun deleteAllTimetableFrame(semester: String): Result<Unit> =
-        runCatching {
+        safeApiCall {
             timetableRemoteDataSource.deleteAllTimetableFrame(semester)
         }
 }

--- a/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
@@ -149,7 +149,7 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun updateUser(user: User): Result<Unit> = runCatching {
+    override suspend fun updateUser(user: User): Result<Unit> = safeApiCall {
         when (user) {
             User.Anonymous -> throw IllegalAccessException("Updating anonymous user is not supported")
             is User.Student -> {
@@ -164,12 +164,12 @@ class UserRepositoryImpl @Inject constructor(
         }
     }.onSuccess {
         userLocalDataSource.updateUserInfo(user)
-    }.mapHttpFailure(
-        e400 = KoinUserException.DataInvalidException(),
-        e401 = KoinUserException.UnauthorizedException(),
-        e404 = KoinUserException.UserNotFoundException(),
-        e409 = KoinUserException.NicknameOrEmailConflictException()
-    )
+    }.mapHttpFailure {
+        on(400) throws KoinUserException.DataInvalidException()
+        on(401) throws KoinUserException.UnauthorizedException()
+        on(404) throws KoinUserException.UserNotFoundException()
+        on(409) throws KoinUserException.NicknameOrEmailConflictException()
+    }
 
     override suspend fun deleteDeviceToken() {
         tokenLocalDataSource.removeDeviceToken()
@@ -204,146 +204,146 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun updateUserPassword(
         hashedPassword: String
     ): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.updateUserPassword(hashedPassword) // TODO: Handle error after error code PR is completed.
         }
     }
 
     override suspend fun requestSmsVerification(phoneNumber: String): Result<CodeCount> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.sendSMS(SmsSendRequest(phoneNumber)).toCodeCount()
-        }.mapHttpFailure(
-            e400 = KoinUserException.PhoneNumberInvalidException(),
-            e429 = KoinUserException.VerificationCodeRequestCountExceededException()
-        )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.PhoneNumberInvalidException()
+            on(429) throws KoinUserException.VerificationCodeRequestCountExceededException()
+        }
     }
 
     override suspend fun requestEmailVerification(email: String): Result<CodeCount> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.sendEmail(EmailSendRequest(email)).toCodeCount()
-        }.mapHttpFailure(
-            e400 = KoinUserException.EmailInvalidException(),
-            e429 = KoinUserException.VerificationCodeRequestCountExceededException()
-        )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.EmailInvalidException()
+            on(429) throws KoinUserException.VerificationCodeRequestCountExceededException()
+        }
     }
 
     override suspend fun verifyCertificationCode(phoneNumber: String, verificationCode: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.verifyCode(
                 SmsVerifyRequest(
                     phoneNumber = phoneNumber,
                     verificationCode = verificationCode
                 )
             )
-        }.mapHttpFailure(
-            e400 = KoinUserException.VerificationCodeInvalidException(),
-            e404 = KoinUserException.VerificationCodeExpiredException()
-        )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.VerificationCodeInvalidException()
+            on(404) throws KoinUserException.VerificationCodeExpiredException()
+        }
     }
 
     override suspend fun verifyEmailCode(email: String, verificationCode: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.verifyEmailCode(
                 EmailVerifyRequest(
                     email = email,
                     verificationCode = verificationCode
                 )
             )
-        }.mapHttpFailure(
-            e400 = KoinUserException.VerificationCodeInvalidException(),
-            e404 = KoinUserException.VerificationCodeExpiredException()
-        )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.VerificationCodeInvalidException()
+            on(404) throws KoinUserException.VerificationCodeExpiredException()
+        }
     }
 
     override suspend fun checkIdExists(loginId: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.idExists(loginId)
-        }.mapHttpFailure(
-            e400 = KoinUserException.LoginIdInvalidException(),
-            e404 = KoinUserException.LoginIdNotFoundException()
-        )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.LoginIdInvalidException()
+            on(404) throws KoinUserException.LoginIdNotFoundException()
+        }
     }
 
     override suspend fun checkIdMatchEmail(loginId: String, email: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.idMatchEmail(loginId, email)
-        }.mapHttpFailure(
-            e400 = KoinUserException.LoginIdNotMatchEmailException(),
-            e404 = KoinUserException.LoginIdNotFoundException()
-        )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.LoginIdNotMatchEmailException()
+            on(404) throws KoinUserException.LoginIdNotFoundException()
+        }
     }
 
     override suspend fun checkIdMatchPhone(loginId: String, phone: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.idMatchPhone(
                 loginId,
                 phone
             )
-        }.mapHttpFailure(
-            e400 = KoinUserException.LoginIdNotMatchPhoneException(),
-            e404 = KoinUserException.LoginIdNotFoundException()
-        )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.LoginIdNotMatchPhoneException()
+            on(404) throws KoinUserException.LoginIdNotFoundException()
+        }
     }
 
     override suspend fun resetPasswordByEmail(loginId: String, email: String, newPassword: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.resetPasswordByEmail(
                 loginId,
                 email,
                 newPassword
             )
-        }.mapHttpFailure(
-            e400 = KoinUserException.LoginIdNotMatchEmailException(),
-            e401 = KoinUserException.UnauthorizedException(),
-            e404 = KoinUserException.LoginIdNotFoundException()
-        )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.LoginIdNotMatchEmailException()
+            on(401) throws KoinUserException.UnauthorizedException()
+            on(404) throws KoinUserException.LoginIdNotFoundException()
+        }
     }
 
     override suspend fun resetPasswordBySms(loginId: String, phone: String, newPassword: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.resetPasswordBySms(loginId, phone, newPassword)
-        }.mapHttpFailure(
-            e400 = KoinUserException.LoginIdNotMatchPhoneException(),
-            e401 = KoinUserException.UnauthorizedException(),
-            e404 = KoinUserException.LoginIdNotFoundException()
-        )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.LoginIdNotMatchPhoneException()
+            on(401) throws KoinUserException.UnauthorizedException()
+            on(404) throws KoinUserException.LoginIdNotFoundException()
+        }
     }
 
     override suspend fun checkEmailExists(email: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.checkEmailExists(email)
-        }.mapHttpFailure(
-            e400 = KoinUserException.EmailInvalidException(),
-            e404 = KoinUserException.EmailNotFoundException()
-        )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.EmailInvalidException()
+            on(404) throws KoinUserException.EmailNotFoundException()
+        }
     }
 
     override suspend fun checkPhoneExists(phone: String): Result<Unit> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.checkPhoneExists(phone)
-        }.mapHttpFailure(
-            e400 = KoinUserException.PhoneNumberInvalidException(),
-            e404 = KoinUserException.PhoneNumberNotFoundException()
-        )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.PhoneNumberInvalidException()
+            on(404) throws KoinUserException.PhoneNumberNotFoundException()
+        }
     }
 
     override suspend fun findLoginIdByEmail(email: String, verificationCode: String): Result<String> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.findLoginIdByEmail(EmailVerifyRequest(email, verificationCode)).loginId
-        }.mapHttpFailure(
-            e400 = KoinUserException.EmailInvalidException(),
-            e401 = KoinUserException.UnauthorizedException(),
-            e404 = KoinUserException.EmailNotFoundException()
-        )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.EmailInvalidException()
+            on(401) throws KoinUserException.UnauthorizedException()
+            on(404) throws KoinUserException.EmailNotFoundException()
+        }
     }
 
     override suspend fun findLoginIdBySms(phone: String, verificationCode: String): Result<String> {
-        return runCatching {
+        return safeApiCall {
             userRemoteDataSource.findLoginIdBySms(SmsVerifyRequest(phone, verificationCode)).loginId
-        }.mapHttpFailure(
-            e400 = KoinUserException.PhoneNumberInvalidException(),
-            e401 = KoinUserException.UnauthorizedException(),
-            e404 = KoinUserException.PhoneNumberNotFoundException()
-        )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.PhoneNumberInvalidException()
+            on(401) throws KoinUserException.UnauthorizedException()
+            on(404) throws KoinUserException.PhoneNumberNotFoundException()
+        }
     }
 }

--- a/data/src/main/java/in/koreatech/koin/data/util/NetworkUtil.kt
+++ b/data/src/main/java/in/koreatech/koin/data/util/NetworkUtil.kt
@@ -4,6 +4,7 @@ import com.google.gson.Gson
 import `in`.koreatech.koin.data.response.ErrorResponse
 import `in`.koreatech.koin.domain.error.KoinErrorException
 import `in`.koreatech.koin.domain.error.KoinUnknownErrorException
+import kotlin.coroutines.cancellation.CancellationException
 import retrofit2.HttpException
 
 fun HttpException.getErrorResponse(): ErrorResponse {
@@ -28,6 +29,7 @@ fun <T> Result<T>.mapHttpFailure(
     e500: KoinErrorException? = null
 ): Result<T> {
     val exception = exceptionOrNull() ?: return this
+    if (exception is CancellationException) throw exception
     if (exception is HttpException) {
         val default = exception.getErrorResponse().toKoinUnknownErrorException()
         val mapped = when (exception.code()) {
@@ -67,6 +69,7 @@ fun <T> Result<T>.mapHttpFailure(
     block: HttpExceptionMapper.() -> Unit
 ): Result<T> {
     val exception = exceptionOrNull() ?: return this
+    if (exception is CancellationException) throw exception
     if (exception !is HttpException) return this
     val mapper = HttpExceptionMapper(exception)
     mapper.block()


### PR DESCRIPTION
## PR 개요
이슈 번호: #15

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- NetworkUtil의 mapHttpFailure 확장 함수 2종(DSL 형태 및 deprecated된 named-parameter 형태)에 `CancellationException` 발생 시 즉시 re-throw 하도록 안전 가드 로직을 추가했습니다.
- data 계층 내 여러 Repository 구현체에서 `runCatching`을 사용하던 부분을 `safeApiCall`로 전환하여 `CancellationException`이 올바르게 전파되도록 수정했습니다.
- `TimetableRepositoryImpl` 내 `putTimetableLectures`의 경우, `safeApiCall`이 non-inline 함수이므로 비지역 반환(non-local return)이 불가하여 `fold` 패턴으로 변경했습니다.
- `UserRepositoryImpl`에서 사용되던 deprecated된 `mapHttpFailure` 호출을 DSL 형태(`on(...)`)로 표준화했습니다.

### 논의 사항
(없음)

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다